### PR TITLE
Add build and deploy workflow

### DIFF
--- a/.github/workflows/build_deploy.yml
+++ b/.github/workflows/build_deploy.yml
@@ -7,12 +7,9 @@ on:
       - published
 
 jobs:
-  build_wheels:
-    name: Build wheels on ${{ matrix.os }}
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ubuntu-18.04, windows-latest, macos-latest]
+  build_wheel:
+    name: Build wheels
+    runs-on: ubuntu-18.04
 
     steps:
       - uses: actions/checkout@v2
@@ -25,15 +22,9 @@ jobs:
         with:
           python-version: '3.8'
 
-      - name: Install cibuildwheel
-        run: |
-          python -m pip install cibuildwheel==1.6.3
-
       - name: Build wheels
         run: |
-          python -m cibuildwheel --output-dir wheelhouse
-        env:
-          CIBW_SKIP: cp27-* cp35-*
+          pip wheel -w wheelhouse .
 
       - uses: actions/upload-artifact@v2
         with:
@@ -62,7 +53,7 @@ jobs:
           path: dist/*.tar.gz
 
   upload_pypi:
-    needs: [build_wheels, build_sdist]
+    needs: [build_wheel, build_sdist]
     runs-on: ubuntu-latest
     if: github.event_name == 'release' && github.event.action == 'published'
     steps:


### PR DESCRIPTION
This github workflow will test building wheels on each commit. It will
also build and deploy to PyPI when a github release is published.

We're also going to have to add `PYPI_TOKEN` to the github secrets.
