### PR TITLE
chore(mypy): tweak mypy options and add more typing

### DIFF
--- a/riot/riot.py
+++ b/riot/riot.py
@@ -10,7 +10,6 @@ import typing as t
 
 import attr
 
-
 logger = logging.getLogger(__name__)
 
 
@@ -18,7 +17,17 @@ SHELL = "/bin/bash"
 ENCODING = "utf-8"
 
 
-class AttrDict(dict):
+if t.TYPE_CHECKING or sys.version_info[:2] >= (3, 9):
+    _T_CompletedProcess = subprocess.CompletedProcess[str]
+else:
+    _T_CompletedProcess = subprocess.CompletedProcess
+
+
+_K = t.TypeVar("_K")
+_V = t.TypeVar("_V")
+
+
+class AttrDict(t.Dict[_K, _V]):
     def __init__(self, *args, **kwargs):
         super(AttrDict, self).__init__(*args, **kwargs)
         self.__dict__ = self
@@ -51,7 +60,7 @@ class Venv:
 
     def instances(
         self,
-        pattern: t.Pattern,
+        pattern: t.Pattern[str],
         parents: t.List["Venv"] = [],
     ) -> t.Generator["VenvInstance", None, None]:
         for venv in self.venvs:
@@ -88,8 +97,8 @@ class VenvInstance:
     name: t.Optional[str] = attr.ib()
     py: float = attr.ib()
     command: str = attr.ib()
-    env: t.List[t.Tuple[str, str]] = attr.ib()
-    pkgs: t.List[t.Tuple[str, str]] = attr.ib()
+    env: t.Tuple[t.Tuple[str, str]] = attr.ib()
+    pkgs: t.Tuple[t.Tuple[str, str]] = attr.ib()
 
 
 @attr.s
@@ -126,14 +135,14 @@ class Session:
 
     def run(
         self,
-        pattern: t.Pattern,
-        skip_base_install=False,
-        recreate_venvs=False,
+        pattern: t.Pattern[str],
+        skip_base_install: bool = False,
+        recreate_venvs: bool = False,
         out: t.TextIO = sys.stdout,
-        pass_env=False,
-        cmdargs=None,
-        pythons=[],
-    ):
+        pass_env: bool = False,
+        cmdargs: t.Optional[str] = None,
+        pythons: t.Optional[t.Set[str]] = None,
+    ) -> None:
         results = []
 
         self.generate_base_venvs(
@@ -260,7 +269,13 @@ class Session:
             py_str = f"Python {inst.py}"
             print(f"{inst.name} {env_str} {py_str} {pkgs_str}", file=out)
 
-    def generate_base_venvs(self, pattern: t.Pattern, recreate, skip_deps, pythons):
+    def generate_base_venvs(
+        self,
+        pattern: t.Pattern[str],
+        recreate: bool,
+        skip_deps: bool,
+        pythons: t.Optional[t.Set[str]],
+    ) -> None:
         """Generate all the required base venvs."""
         # Find all the python versions used.
         required_pys = set([inst.py for inst in self.venv.instances(pattern=pattern)])
@@ -296,13 +311,13 @@ class Session:
                     sys.exit(1)
 
 
-def rmchars(chars: str, s: str):
+def rmchars(chars: str, s: str) -> str:
     for c in chars:
         s = s.replace(c, "")
     return s
 
 
-def get_pep_dep(libname: str, version: str):
+def get_pep_dep(libname: str, version: str) -> str:
     """Return a valid PEP 508 dependency string.
 
     ref: https://www.python.org/dev/peps/pep-0508/
@@ -310,7 +325,7 @@ def get_pep_dep(libname: str, version: str):
     return f"{libname}{version}"
 
 
-def get_env_str(envs: t.List[t.Tuple[str, str]]):
+def get_env_str(envs: t.Sequence[t.Tuple[str, str]]) -> str:
     return " ".join(f"{k}={v}" for k, v in envs)
 
 
@@ -320,23 +335,29 @@ def get_base_venv_path(pyversion):
     return f".riot/.venv_py{pyversion}"
 
 
-def run_cmd(*args, **kwargs):
-    # Provide our own defaults.
-    if "shell" in kwargs and "executable" not in kwargs:
-        kwargs["executable"] = SHELL
-    if "encoding" not in kwargs:
-        kwargs["encoding"] = ENCODING
-    if "stdout" not in kwargs:
-        kwargs["stdout"] = subprocess.PIPE
+_T_stdio = t.Union[None, int, t.IO[t.Any]]
+
+
+def run_cmd(
+    args: t.Union[str, t.Sequence[str]],
+    shell: bool = False,
+    stdout: _T_stdio = subprocess.PIPE,
+    cmdargs: t.Optional[str] = None,
+    executable: t.Optional[str] = None,
+) -> _T_CompletedProcess:
+    if shell:
+        executable = SHELL
 
     # insert command args if passed
-    if "cmdargs" in kwargs:
-        cmd = args[0]
-        args = (cmd.format(cmdargs=kwargs["cmdargs"]),) + args[1:]
-        del kwargs["cmdargs"]
+    if cmdargs is not None:
+        if not isinstance(args, str):
+            # FIXME(jd): make it work
+            raise RuntimeError("Cannot use cmdargs with non-string command")
+        args = args.format(cmdargs=cmdargs)
 
-    logger.debug("Running command %s", args[0])
-    r = subprocess.run(*args, **kwargs)
+    logger.debug("Running command %s", args)
+    # FIXME Remove type: ignore when https://github.com/python/typeshed/pull/4789 is released
+    r = subprocess.run(args, encoding=ENCODING, stdout=stdout, executable=executable, shell=shell)  # type: ignore[arg-type]
     logger.debug(r.stdout)
 
     if r.returncode != 0:
@@ -370,33 +391,41 @@ def create_base_venv(pyversion, path=None, recreate=True):
     return path
 
 
-def get_venv_command(venv_path, cmd):
+def get_venv_command(venv_path: str, cmd: str) -> str:
     """Return the command string used to execute `cmd` in virtual env located at `venv_path`."""
     return f"source {venv_path}/bin/activate && {cmd}"
 
 
-def run_cmd_venv(venv, cmd, **kwargs):
-    env = kwargs.get("env") or {}
+def run_cmd_venv(
+    venv: str,
+    args: str,
+    stdout: _T_stdio = subprocess.PIPE,
+    cmdargs: t.Optional[str] = None,
+    executable: t.Optional[str] = None,
+    env: t.Dict[str, str] = None,
+) -> _T_CompletedProcess:
+    cmd = get_venv_command(venv, args)
+
+    if env is None:
+        env = {}
+
     env_str = " ".join(f"{k}={v}" for k, v in env.items())
-    cmd = get_venv_command(venv, cmd)
 
     logger.debug("Executing command '%s' with environment '%s'", cmd, env_str)
-    r = run_cmd(cmd, shell=True, **kwargs)
-    return r
+    return run_cmd(
+        cmd, stdout=stdout, cmdargs=cmdargs, executable=executable, shell=True
+    )
 
 
-def expand_specs(specs):
+def expand_specs(specs: t.Dict[_K, t.List[_V]]) -> t.Iterator[t.Tuple[t.Tuple[_K, _V]]]:
     """Return the product of all items from the passed dictionary.
 
     In summary:
 
-    [(X, [X0, X1, ...]), (Y, [Y0, Y1, ...)] ->
-      ((X, X0), (Y, Y0)), ((X, X0), (Y, Y1)), ((X, X1), (Y, Y0)), ((X, X1), (Y, Y1))
+    {X: [X0, X1, ...], Y: [Y0, Y1, ...]} ->
+      [(X, X0), (Y, Y0)), ((X, X0), (Y, Y1)), ((X, X1), (Y, Y0)), ((X, X1), (Y, Y1)]
     """
-    all_vals = []
+    all_vals = [[(name, val) for val in vals] for name, vals in specs.items()]
 
-    for name, vals in specs.items():
-        all_vals.append([(name, val) for val in vals])
-
-    all_vals = itertools.product(*all_vals)
-    return all_vals
+    # Need to cast because the * star typeshed of itertools.product returns Any
+    return t.cast(t.Iterator[t.Tuple[t.Tuple[_K, _V]]], itertools.product(*all_vals))

--- a/riotfile.py
+++ b/riotfile.py
@@ -39,7 +39,7 @@ venv = Venv(
         ),
         Venv(
             name="typing",
-            command="mypy riot/ tests/",
+            command="mypy",
             pkgs={
                 "mypy": [""],
                 "pytest": [""],

--- a/setup.cfg
+++ b/setup.cfg
@@ -11,3 +11,11 @@ exclude=
 # We ignore most of the D errors because there are too many; the goal is to fix them eventually
 ignore = E501,W503,E231,G201,D100,D101,D102,D103,D104,D107
 enable-extensions=G
+
+[mypy]
+ignore_missing_imports = true
+disallow_incomplete_defs = true
+warn_unused_ignores = true
+warn_unused_configs = true
+disallow_any_generics = true
+files = riot,tests

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -40,28 +40,28 @@ def without_riotfile(
         yield
 
 
-def test_main(cli: click.testing.CliRunner):
+def test_main(cli: click.testing.CliRunner) -> None:
     """Running main with no command returns usage."""
     result = cli.invoke(riot.cli.main)
     assert result.exit_code == 0
     assert result.stdout.startswith("Usage: main")
 
 
-def test_main_help(cli: click.testing.CliRunner):
+def test_main_help(cli: click.testing.CliRunner) -> None:
     """Running main with --help returns usage."""
     result = cli.invoke(riot.cli.main, ["--help"])
     assert result.exit_code == 0
     assert result.stdout.startswith("Usage: main")
 
 
-def test_main_version(cli: click.testing.CliRunner):
+def test_main_version(cli: click.testing.CliRunner) -> None:
     """Running main with --version returns version string."""
     result = cli.invoke(riot.cli.main, ["--version"])
     assert result.exit_code == 0
     assert result.stdout.startswith("main, version ")
 
 
-def test_list_empty(cli: click.testing.CliRunner):
+def test_list_empty(cli: click.testing.CliRunner) -> None:
     """Running list with an empty riotfile prints nothing."""
     with with_riotfile(cli, "empty_riotfile.py"):
         result = cli.invoke(riot.cli.main, ["list"])
@@ -69,7 +69,7 @@ def test_list_empty(cli: click.testing.CliRunner):
         assert result.stdout == ""
 
 
-def test_list_no_riotfile(cli: click.testing.CliRunner):
+def test_list_no_riotfile(cli: click.testing.CliRunner) -> None:
     """Running list with no riotfile fails with an error."""
     with without_riotfile(cli):
         result = cli.invoke(riot.cli.main, ["list"])
@@ -80,7 +80,7 @@ def test_list_no_riotfile(cli: click.testing.CliRunner):
         )
 
 
-def test_list_default_pattern(cli: click.testing.CliRunner):
+def test_list_default_pattern(cli: click.testing.CliRunner) -> None:
     """Running list with no pattern passes through the default pattern."""
     with mock.patch("riot.cli.Session.list_venvs") as list_venvs:
         with with_riotfile(cli, "empty_riotfile.py"):
@@ -93,7 +93,7 @@ def test_list_default_pattern(cli: click.testing.CliRunner):
             assert list_venvs.call_args.args[0].pattern == ".*"
 
 
-def test_list_with_pattern(cli: click.testing.CliRunner):
+def test_list_with_pattern(cli: click.testing.CliRunner) -> None:
     """Running list with a pattern passes through the pattern."""
     with mock.patch("riot.cli.Session.list_venvs") as list_venvs:
         with with_riotfile(cli, "empty_riotfile.py"):
@@ -106,7 +106,7 @@ def test_list_with_pattern(cli: click.testing.CliRunner):
             assert list_venvs.call_args.args[0].pattern == "^pattern.*"
 
 
-def test_run(cli: click.testing.CliRunner):
+def test_run(cli: click.testing.CliRunner) -> None:
     """Running run with default options."""
     with mock.patch("riot.cli.Session.run") as run:
         with with_riotfile(cli, "empty_riotfile.py"):
@@ -133,7 +133,7 @@ def test_run(cli: click.testing.CliRunner):
             assert kwargs["pass_env"] is False
 
 
-def test_run_with_long_args(cli: click.testing.CliRunner):
+def test_run_with_long_args(cli: click.testing.CliRunner) -> None:
     """Running run with long option names uses those options."""
     with mock.patch("riot.cli.Session.run") as run:
         with with_riotfile(cli, "empty_riotfile.py"):
@@ -163,7 +163,7 @@ def test_run_with_long_args(cli: click.testing.CliRunner):
             assert kwargs["pass_env"] is True
 
 
-def test_run_with_short_args(cli: click.testing.CliRunner):
+def test_run_with_short_args(cli: click.testing.CliRunner) -> None:
     """Running run with short option names uses those options."""
     with mock.patch("riot.cli.Session.run") as run:
         with with_riotfile(cli, "empty_riotfile.py"):
@@ -190,7 +190,7 @@ def test_run_with_short_args(cli: click.testing.CliRunner):
             assert kwargs["pass_env"] is False
 
 
-def test_run_with_pattern(cli: click.testing.CliRunner):
+def test_run_with_pattern(cli: click.testing.CliRunner) -> None:
     """Running run with pattern passes in that pattern."""
     with mock.patch("riot.cli.Session.run") as run:
         with with_riotfile(cli, "empty_riotfile.py"):
@@ -217,7 +217,7 @@ def test_run_with_pattern(cli: click.testing.CliRunner):
             assert kwargs["pass_env"] is False
 
 
-def test_generate_suites_with_long_args(cli: click.testing.CliRunner):
+def test_generate_suites_with_long_args(cli: click.testing.CliRunner) -> None:
     """Generatening generate with long option names uses those options."""
     with mock.patch("riot.cli.Session.generate_base_venvs") as generate_base_venvs:
         with with_riotfile(cli, "empty_riotfile.py"):
@@ -239,7 +239,7 @@ def test_generate_suites_with_long_args(cli: click.testing.CliRunner):
             assert kwargs["skip_deps"] is True
 
 
-def test_generate_base_venvs_with_short_args(cli: click.testing.CliRunner):
+def test_generate_base_venvs_with_short_args(cli: click.testing.CliRunner) -> None:
     """Generatening generate with short option names uses those options."""
     with mock.patch("riot.cli.Session.generate_base_venvs") as generate_base_venvs:
         with with_riotfile(cli, "empty_riotfile.py"):
@@ -258,7 +258,7 @@ def test_generate_base_venvs_with_short_args(cli: click.testing.CliRunner):
             assert kwargs["skip_deps"] is True
 
 
-def test_generate_base_venvs_with_pattern(cli: click.testing.CliRunner):
+def test_generate_base_venvs_with_pattern(cli: click.testing.CliRunner) -> None:
     """Generatening generate with pattern passes in that pattern."""
     with mock.patch("riot.cli.Session.generate_base_venvs") as generate_base_venvs:
         with with_riotfile(cli, "empty_riotfile.py"):
@@ -288,7 +288,7 @@ def test_generate_base_venvs_with_pattern(cli: click.testing.CliRunner):
 )
 def test_run_suites_cmdargs_not_set(
     cli: click.testing.CliRunner, name: str, cmdargs: str, cmdrun: str
-):
+) -> None:
     """Running command with optional infix cmdargs."""
     with cli.isolated_filesystem():
         with open("riotfile.py", "w") as f:
@@ -335,7 +335,7 @@ venv = Venv(
             assert cmd.endswith(cmdrun)
 
 
-def test_nested_venv(cli: click.testing.CliRunner):
+def test_nested_venv(cli: click.testing.CliRunner) -> None:
     with cli.isolated_filesystem():
         with open("riotfile.py", "w") as f:
             f.write(


### PR DESCRIPTION
- Enable `ignore_missing_imports` so we don't fail on missing typing for
  external libs
- Disallow incomplete defs to make sure we have fully documented type on every
  typed function
- Warn on unused configs and ignore directives
- Disallow usage of Any
- Specify files to check
