### PR TITLE
Run coverage job with riot

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -47,6 +47,4 @@ jobs:
       - name: Run tests
         run: riot -v run --python=${{ matrix.python-version }} test
       - name: Coverage
-        run: |
-          pip install coverage
-          bash <(curl -s https://codecov.io/bash)
+        run: riot -v run --python=${{ matrix.python-version }} codecov

--- a/riotfile.py
+++ b/riotfile.py
@@ -46,5 +46,13 @@ venv = Venv(
                 "pytest": [""],
             },
         ),
+        Venv(
+            pys=[3.6, 3.7, 3.8, 3.9],
+            name="codecov",
+            command="bash <(curl -s https://codecov.io/bash)",
+            pkgs={
+                "coverage": [""],
+            },
+        ),
     ],
 )


### PR DESCRIPTION
It's a bit awkward because a different python is available each time so we need to specify `pys=[3.6, 3.7, 3.8, 3.9]` and then select the one that's available.