### PR TITLE
fix: do not specify encoding

### DIFF
--- a/riot/riot.py
+++ b/riot/riot.py
@@ -14,7 +14,7 @@ logger = logging.getLogger(__name__)
 
 
 SHELL = "/bin/bash"
-ENCODING = "utf-8"
+ENCODING = sys.getdefaultencoding()
 
 
 if t.TYPE_CHECKING or sys.version_info[:2] >= (3, 9):


### PR DESCRIPTION
riot should just be a serving hatch and not mess with user encoding in any way,
use the system default one.
