### PR TITLE
fix: do not use cp to copy trees

### DIFF
--- a/riot/riot.py
+++ b/riot/riot.py
@@ -192,7 +192,7 @@ class Session:
                     )
                     try:
                         shutil.copytree(base_venv, venv_name)
-                    except FileNotFoundError as e:
+                    except FileNotFoundError:
                         logger.info("Base virtualenv '%s' does not exists", venv_name)
                         continue
                     except FileExistsError:

--- a/riot/riot.py
+++ b/riot/riot.py
@@ -193,7 +193,7 @@ class Session:
                     try:
                         shutil.copytree(base_venv, venv_name)
                     except FileNotFoundError:
-                        logger.info("Base virtualenv '%s' does not exists", venv_name)
+                        logger.info("Base virtualenv '%s' does not exist", venv_name)
                         continue
                     except FileExistsError:
                         # Assume the venv already exists and works fine

--- a/riot/riot.py
+++ b/riot/riot.py
@@ -191,14 +191,13 @@ class Session:
                         venv_name,
                     )
                     try:
-                        run_cmd(
-                            ["cp", "-r", base_venv, venv_name], stdout=subprocess.PIPE
-                        )
-                    except CmdFailure as e:
-                        raise CmdFailure(
-                            f"Failed to create virtualenv '{venv_name}'\n{e.proc.stdout}",
-                            e.proc,
-                        )
+                        shutil.copytree(base_venv, venv_name)
+                    except FileNotFoundError as e:
+                        logger.info("Base virtualenv '%s' does not exists", venv_name)
+                        continue
+                    except FileExistsError:
+                        # Assume the venv already exists and works fine
+                        logger.info("Virtualenv '%s' already exists", venv_name)
 
                     logger.info("Installing venv dependencies %s.", pkg_str)
                     try:


### PR DESCRIPTION
The current use of `cp` is more-or-less portable but is broken:

`cp -r foo bar` copies foo as bar the first time but `cp -r foo bar` copies
`foo` *into* `bar` the second time.