### PR TITLE
Add --python option to riot list command

### DIFF
--- a/riot/cli.py
+++ b/riot/cli.py
@@ -49,11 +49,12 @@ def main(ctx, riotfile, log_level):
     ctx.obj["session"] = Session.from_config_file(riotfile)
 
 
-@main.command("list", help="List sessions")
+@main.command("list", help="List venvs")
+@PYTHON_VERSIONS_ARG
 @PATTERN_ARG
 @click.pass_context
-def list_venvs(ctx, pattern):
-    ctx.obj["session"].list_venvs(re.compile(pattern))
+def list_venvs(ctx, pythons, pattern):
+    ctx.obj["session"].list_venvs(re.compile(pattern), pythons=pythons)
 
 
 @main.command(help="Generate virtual environments")

--- a/riot/riot.py
+++ b/riot/riot.py
@@ -59,9 +59,7 @@ class Venv:
             return venv
 
     def instances(
-        self,
-        pattern: t.Pattern[str],
-        parents: t.List["Venv"] = [],
+        self, pattern: t.Pattern[str], parents: t.List["Venv"] = [],
     ) -> t.Generator["VenvInstance", None, None]:
         for venv in self.venvs:
             if venv.name and not pattern.match(venv.name):
@@ -260,7 +258,7 @@ class Session:
         if any(True for r in results if r.code != 0):
             sys.exit(1)
 
-    def list_venvs(self, pattern, pythons: t.Optional[t.Set[str]] = None, out=sys.stdout):
+    def list_venvs(self, pattern, pythons=None, out=sys.stdout):
         for inst in self.venv.instances(pattern=pattern):
             if pythons and inst.py not in pythons:
                 continue

--- a/riot/riot.py
+++ b/riot/riot.py
@@ -59,7 +59,9 @@ class Venv:
             return venv
 
     def instances(
-        self, pattern: t.Pattern[str], parents: t.List["Venv"] = [],
+        self,
+        pattern: t.Pattern[str],
+        parents: t.List["Venv"] = [],
     ) -> t.Generator["VenvInstance", None, None]:
         for venv in self.venvs:
             if venv.name and not pattern.match(venv.name):

--- a/riot/riot.py
+++ b/riot/riot.py
@@ -260,8 +260,10 @@ class Session:
         if any(True for r in results if r.code != 0):
             sys.exit(1)
 
-    def list_venvs(self, pattern, out=sys.stdout):
+    def list_venvs(self, pattern, pythons: t.Optional[t.Set[str]] = None, out=sys.stdout):
         for inst in self.venv.instances(pattern=pattern):
+            if pythons and inst.py not in pythons:
+                continue
             pkgs_str = " ".join(
                 f"'{get_pep_dep(name, version)}'" for name, version in inst.pkgs
             )

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -116,12 +116,15 @@ def test_list_with_python(cli: click.testing.CliRunner) -> None:
             assert result.stdout == ""
 
             list_venvs.assert_called_once()
-            assert list_venvs.call_args.kwargs["pythons"] == (3.6, )
+            assert list_venvs.call_args.kwargs["pythons"] == (3.6,)
 
     # multiple pythons
     with mock.patch("riot.cli.Session.list_venvs") as list_venvs:
         with with_riotfile(cli, "empty_riotfile.py"):
-            result = cli.invoke(riot.cli.main, ["list", "--python", "3.6", "-p", "3.8", "--python", "2.7"])
+            result = cli.invoke(
+                riot.cli.main,
+                ["list", "--python", "3.6", "-p", "3.8", "--python", "2.7"],
+            )
             # Success, but no output because we don't have a matching pattern
             assert result.exit_code == 0
             assert result.stdout == ""
@@ -246,8 +249,7 @@ def test_generate_suites_with_long_args(cli: click.testing.CliRunner) -> None:
     with mock.patch("riot.cli.Session.generate_base_venvs") as generate_base_venvs:
         with with_riotfile(cli, "empty_riotfile.py"):
             result = cli.invoke(
-                riot.cli.main,
-                ["generate", "--recreate-venvs", "--skip-base-install"],
+                riot.cli.main, ["generate", "--recreate-venvs", "--skip-base-install"],
             )
             # Success, but no output because we mock generate_base_venvs
             assert result.exit_code == 0

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -249,7 +249,8 @@ def test_generate_suites_with_long_args(cli: click.testing.CliRunner) -> None:
     with mock.patch("riot.cli.Session.generate_base_venvs") as generate_base_venvs:
         with with_riotfile(cli, "empty_riotfile.py"):
             result = cli.invoke(
-                riot.cli.main, ["generate", "--recreate-venvs", "--skip-base-install"],
+                riot.cli.main,
+                ["generate", "--recreate-venvs", "--skip-base-install"],
             )
             # Success, but no output because we mock generate_base_venvs
             assert result.exit_code == 0

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -106,6 +106,30 @@ def test_list_with_pattern(cli: click.testing.CliRunner) -> None:
             assert list_venvs.call_args.args[0].pattern == "^pattern.*"
 
 
+def test_list_with_python(cli: click.testing.CliRunner) -> None:
+    """Running list with a python passes through the python."""
+    with mock.patch("riot.cli.Session.list_venvs") as list_venvs:
+        with with_riotfile(cli, "empty_riotfile.py"):
+            result = cli.invoke(riot.cli.main, ["list", "--python", "3.6"])
+            # Success, but no output because we don't have a matching pattern
+            assert result.exit_code == 0
+            assert result.stdout == ""
+
+            list_venvs.assert_called_once()
+            assert list_venvs.call_args.kwargs["pythons"] == (3.6, )
+
+    # multiple pythons
+    with mock.patch("riot.cli.Session.list_venvs") as list_venvs:
+        with with_riotfile(cli, "empty_riotfile.py"):
+            result = cli.invoke(riot.cli.main, ["list", "--python", "3.6", "-p", "3.8", "--python", "2.7"])
+            # Success, but no output because we don't have a matching pattern
+            assert result.exit_code == 0
+            assert result.stdout == ""
+
+            list_venvs.assert_called_once()
+            assert list_venvs.call_args.kwargs["pythons"] == (3.6, 3.8, 2.7)
+
+
 def test_run(cli: click.testing.CliRunner) -> None:
     """Running run with default options."""
     with mock.patch("riot.cli.Session.run") as run:


### PR DESCRIPTION
Adding the ability to provide `--python` to the `riot list` command.


```
$ riot list
test LC_ALL=C.UTF-8 LANG=C.UTF-8 Python 3.6 'pytest' 'pytest-cov' 'mock'
test LC_ALL=C.UTF-8 LANG=C.UTF-8 Python 3.7 'pytest' 'pytest-cov' 'mock'
test LC_ALL=C.UTF-8 LANG=C.UTF-8 Python 3.8 'pytest' 'pytest-cov' 'mock'
test LC_ALL=C.UTF-8 LANG=C.UTF-8 Python 3.9 'pytest' 'pytest-cov' 'mock'
check_format  Python 3.8 'black==20.8b1'
flake8  Python 3.8 'flake8' 'flake8-blind-except' 'flake8-builtins' 'flake8-docstrings' 'flake8-logging-format' 'flake8-rst-docstrings' 'pygments'
typing  Python 3.8 'mypy' 'pytest'
codecov  Python 3.6 'coverage'
codecov  Python 3.7 'coverage'
codecov  Python 3.8 'coverage'
codecov  Python 3.9 'coverage'
docs  Python 3.8 'sphinx==3.3'
```


```
$ riot list --python 3.6
test LC_ALL=C.UTF-8 LANG=C.UTF-8 Python 3.6 'pytest' 'pytest-cov' 'mock'
codecov  Python 3.6 'coverage'
```

```
$ riot list --python 3.8 code
codecov  Python 3.8 'coverage'
```