### PR TITLE
Use extra args for cmdargs

### DIFF
--- a/riot/cli.py
+++ b/riot/cli.py
@@ -72,20 +72,22 @@ def generate(ctx, recreate_venvs, skip_base_install, pythons, pattern):
     )
 
 
-@main.command(help="Run")
+@main.command(
+    help="Run",
+    context_settings=dict(ignore_unknown_options=True, allow_extra_args=True),
+)
 @RECREATE_VENVS_ARG
 @SKIP_BASE_INSTALL_ARG
 @click.option("--pass-env", "pass_env", is_flag=True, default=False)
-@click.option("--cmdargs", "cmdargs", default="")
 @PYTHON_VERSIONS_ARG
 @PATTERN_ARG
 @click.pass_context
-def run(ctx, recreate_venvs, skip_base_install, pass_env, cmdargs, pythons, pattern):
+def run(ctx, recreate_venvs, skip_base_install, pass_env, pythons, pattern):
     ctx.obj["session"].run(
         pattern=re.compile(pattern),
         recreate_venvs=recreate_venvs,
         skip_base_install=skip_base_install,
         pass_env=pass_env,
-        cmdargs=cmdargs,
+        cmdargs=ctx.args,
         pythons=pythons,
     )

--- a/riot/riot.py
+++ b/riot/riot.py
@@ -152,7 +152,7 @@ class Session:
         recreate_venvs: bool = False,
         out: t.TextIO = sys.stdout,
         pass_env: bool = False,
-        cmdargs: t.Optional[str] = None,
+        cmdargs: t.Optional[t.Sequence[str]] = None,
         pythons: t.Optional[t.Set[str]] = None,
     ) -> None:
         results = []
@@ -355,18 +355,18 @@ def run_cmd(
     args: t.Union[str, t.Sequence[str]],
     shell: bool = False,
     stdout: _T_stdio = subprocess.PIPE,
-    cmdargs: t.Optional[str] = None,
+    cmdargs: t.Optional[t.Sequence[str]] = None,
     executable: t.Optional[str] = None,
 ) -> _T_CompletedProcess:
     if shell:
         executable = SHELL
 
-    # insert command args if passed
-    if cmdargs is not None:
-        if not isinstance(args, str):
-            # FIXME(jd): make it work
-            raise RuntimeError("Cannot use cmdargs with non-string command")
-        args = args.format(cmdargs=cmdargs)
+    if cmdargs and not isinstance(args, str):
+        # FIXME(jd): make it work
+        raise RuntimeError("Cannot use cmdargs with non-string command")
+
+    if isinstance(args, str):
+        args = args.format(cmdargs=(" ".join(cmdargs) if cmdargs else ""))
 
     logger.debug("Running command %s", args)
     # FIXME Remove type: ignore when https://github.com/python/typeshed/pull/4789 is released
@@ -413,7 +413,7 @@ def run_cmd_venv(
     venv: str,
     args: str,
     stdout: _T_stdio = subprocess.PIPE,
-    cmdargs: t.Optional[str] = None,
+    cmdargs: t.Optional[t.Sequence[str]] = None,
     executable: t.Optional[str] = None,
     env: t.Dict[str, str] = None,
 ) -> _T_CompletedProcess:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -307,14 +307,14 @@ def test_generate_base_venvs_with_pattern(cli: click.testing.CliRunner) -> None:
 @pytest.mark.parametrize(
     "name,cmdargs,cmdrun",
     [
-        ("test_cmdargs", None, "echo cmdargs="),
-        ("test_cmdargs", "-k filter", "echo cmdargs=-k filter"),
-        ("test_nocmdargs", None, "echo no cmdargs"),
-        ("test_nocmdargs", "-k filter", "echo no cmdargs"),
+        ("test_cmdargs", [], "echo cmdargs="),
+        ("test_cmdargs", ["--", "-k", "filter"], "echo cmdargs=-k filter"),
+        ("test_nocmdargs", [], "echo no cmdargs"),
+        ("test_nocmdargs", ["--", "-k", "filter"], "echo no cmdargs"),
     ],
 )
-def test_run_suites_cmdargs_not_set(
-    cli: click.testing.CliRunner, name: str, cmdargs: str, cmdrun: str
+def test_run_suites_cmdargs(
+    cli: click.testing.CliRunner, name: str, cmdargs: typing.List[str], cmdrun: str
 ) -> None:
     """Running command with optional infix cmdargs."""
     with cli.isolated_filesystem():
@@ -349,9 +349,7 @@ venv = Venv(
             )
         with mock.patch("subprocess.run") as subprocess_run:
             subprocess_run.return_value.returncode = 0
-            args = ["run", name]
-            if cmdargs:
-                args += ["--cmdargs", cmdargs]
+            args = ["run", name] + cmdargs
             result = cli.invoke(riot.cli.main, args, catch_exceptions=False)
             assert result.exit_code == 0
             assert result.stdout == ""


### PR DESCRIPTION
Following suggestion in https://github.com/DataDog/riot/pull/55#issuecomment-733018232

Now we can do:

```
riot run test -p3.8 -- -k test_run_suites_cmdargs
============================================================================================================================== test session starts ===============================================================================================================================
platform darwin -- Python 3.8.6, pytest-6.1.2, py-1.9.0, pluggy-0.13.1
rootdir: /Users/tahir.butt/go/src/github.com/DataDog/riot
plugins: cov-2.10.1
collected 21 items / 17 deselected / 4 selected

tests/test_cli.py ....                                                                                                                                                                                                                                                     [100%]



======================================================================================================================== 4 passed, 17 deselected in 0.34s ========================================================================================================================

-------------------summary-------------------
✔️  test: LC_ALL=C.UTF-8 LANG=C.UTF-8 python3.8 'pytest' 'pytest-cov' 'mock'
```