### PR TITLE
Handle riotfile errors

### DIFF
--- a/riot/cli.py
+++ b/riot/cli.py
@@ -2,6 +2,7 @@ __all__ = ["main"]
 
 import logging
 import re
+import sys
 
 
 import click
@@ -47,7 +48,11 @@ def main(ctx, riotfile, log_level):
         logging.basicConfig(level=log_level)
 
     ctx.ensure_object(dict)
-    ctx.obj["session"] = Session.from_config_file(riotfile)
+    try:
+        ctx.obj["session"] = Session.from_config_file(riotfile)
+    except Exception as e:
+        click.echo(f"Failed to construct config file:\n{str(e)}", err=True)
+        sys.exit(1)
 
 
 @main.command("list", help="List venvs")

--- a/riot/riot.py
+++ b/riot/riot.py
@@ -7,7 +7,11 @@ import os
 import shutil
 import subprocess
 import sys
+import traceback
 import typing as t
+
+import click
+
 
 logger = logging.getLogger(__name__)
 
@@ -158,14 +162,28 @@ class Session:
     @classmethod
     def from_config_file(cls, path: str) -> "Session":
         spec = importlib.util.spec_from_file_location("riotfile", path)
+        if not spec:
+            click.echo(
+                f"Invalid file format for riotfile. Expected file with .py extension got '{path}'.",
+                err=True,
+            )
+            sys.exit(1)
         config = importlib.util.module_from_spec(spec)
 
         # DEV: MyPy has `ModuleSpec.loader` as `Optional[_Loader`]` which doesn't have `exec_module`
         # https://github.com/python/typeshed/blob/fe58699ca5c9ee4838378adb88aaf9323e9bbcf0/stdlib/3/_importlib_modulespec.pyi#L13-L44
-        t.cast(importlib.abc.Loader, spec.loader).exec_module(config)
-
-        venv = getattr(config, "venv", Venv())
-        return cls(venv=venv)
+        try:
+            t.cast(importlib.abc.Loader, spec.loader).exec_module(config)
+        except Exception as e:
+            click.echo(
+                f"Failed to parse riotfile '{path}'.\n{e}",
+                err=True,
+            )
+            click.echo(traceback.format_exc(), err=True)
+            sys.exit(1)
+        else:
+            venv = getattr(config, "venv", Venv())
+            return cls(venv=venv)
 
     def run(
         self,

--- a/riot/riot.py
+++ b/riot/riot.py
@@ -10,8 +10,6 @@ import sys
 import traceback
 import typing as t
 
-import click
-
 
 logger = logging.getLogger(__name__)
 
@@ -163,11 +161,9 @@ class Session:
     def from_config_file(cls, path: str) -> "Session":
         spec = importlib.util.spec_from_file_location("riotfile", path)
         if not spec:
-            click.echo(
-                f"Invalid file format for riotfile. Expected file with .py extension got '{path}'.",
-                err=True,
+            raise Exception(
+                f"Invalid file format for riotfile. Expected file with .py extension got '{path}'."
             )
-            sys.exit(1)
         config = importlib.util.module_from_spec(spec)
 
         # DEV: MyPy has `ModuleSpec.loader` as `Optional[_Loader`]` which doesn't have `exec_module`
@@ -175,12 +171,9 @@ class Session:
         try:
             t.cast(importlib.abc.Loader, spec.loader).exec_module(config)
         except Exception as e:
-            click.echo(
-                f"Failed to parse riotfile '{path}'.\n{e}",
-                err=True,
-            )
-            click.echo(traceback.format_exc(), err=True)
-            sys.exit(1)
+            raise Exception(
+                f"Failed to parse riotfile '{path}'.\n{traceback.format_exc()}"
+            ) from e
         else:
             venv = getattr(config, "venv", Venv())
             return cls(venv=venv)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -480,7 +480,7 @@ venv = Venv(
         assert result.exit_code == 1
         assert (
             result.stdout
-            == "Invalid file format for riotfile. Expected file with .py extension got 'riotfile'.\n"
+            == "Failed to construct config file:\nInvalid file format for riotfile. Expected file with .py extension got 'riotfile'.\n"
         )
 
 


### PR DESCRIPTION
- Handle riotfiles that don't have .py extension
- Handle execution errors of riotfile.py

Fixes #38