### PR TITLE
Provide latest export

### DIFF
--- a/riot/__init__.py
+++ b/riot/__init__.py
@@ -1,3 +1,5 @@
-__all__ = ["Session", "Venv"]
+__all__ = ["latest", "Session", "Venv"]
 
 from .riot import Session, Venv
+
+latest = ""

--- a/riotfile.py
+++ b/riotfile.py
@@ -1,4 +1,4 @@
-from riot import Venv
+from riot import latest, Venv
 
 venv = Venv(
     pys=3.8,
@@ -12,9 +12,9 @@ venv = Venv(
             },
             pys=[3.7, 3.8, 3.9],
             pkgs={
-                "pytest": "",
-                "pytest-cov": "",
-                "mock": "",
+                "pytest": latest,
+                "pytest-cov": latest,
+                "mock": latest,
             },
         ),
         Venv(
@@ -28,23 +28,23 @@ venv = Venv(
             name="flake8",
             command="flake8",
             pkgs={
-                "flake8": "",
-                "flake8-blind-except": "",
-                "flake8-builtins": "",
-                "flake8-docstrings": "",
-                "flake8-import-order": "",
-                "flake8-logging-format": "",
-                "flake8-rst-docstrings": "",
+                "flake8": latest,
+                "flake8-blind-except": latest,
+                "flake8-builtins": latest,
+                "flake8-docstrings": latest,
+                "flake8-import-order": latest,
+                "flake8-logging-format": latest,
+                "flake8-rst-docstrings": latest,
                 # needed for some features from flake8-rst-docstrings
-                "pygments": "",
+                "pygments": latest,
             },
         ),
         Venv(
             name="typing",
             command="mypy",
             pkgs={
-                "mypy": "",
-                "pytest": "",
+                "mypy": latest,
+                "pytest": latest,
             },
         ),
         Venv(
@@ -52,7 +52,7 @@ venv = Venv(
             name="codecov",
             command="bash <(curl -s https://codecov.io/bash)",
             pkgs={
-                "coverage": "",
+                "coverage": latest,
             },
         ),
         Venv(
@@ -60,7 +60,7 @@ venv = Venv(
             command="sphinx-build -W -b html docs docs/_build/",
             pkgs={
                 "sphinx": "==3.3",
-                "reno": "",
+                "reno": latest,
             },
         ),
     ],


### PR DESCRIPTION
This removes the obscure syntax used for picking the latest package.
"latest" isn't the greatest name since this just corresponds to not
specifying a version. It could be taken from the pip cache and not be
the absolute latest.

Fixes #50