### PR TITLE
Cache interpreter version check and path lookup

### DIFF
--- a/riot/riot.py
+++ b/riot/riot.py
@@ -1,4 +1,5 @@
 import dataclasses
+import functools
 import importlib.abc
 import importlib.util
 import itertools
@@ -78,6 +79,7 @@ class Interpreter:
         """Return the path of the interpreter executable."""
         return repr(self)
 
+    @functools.lru_cache()
     def version(self) -> str:
         path = self.path()
 
@@ -85,6 +87,7 @@ class Interpreter:
         version = output.decode().strip().split(" ")[1]
         return version
 
+    @functools.lru_cache()
     def path(self) -> str:
         """Return the Python interpreter path or raise.
 


### PR DESCRIPTION
`riot list` has noticeable performance issues as each entry results in a subprocess invocation of a python interpreter.