### PR TITLE
Add instance selection feature

### DIFF
--- a/releasenotes/notes/selection-89a52c8d0d8476a8.yaml
+++ b/releasenotes/notes/selection-89a52c8d0d8476a8.yaml
@@ -1,0 +1,6 @@
+---
+prelude: >
+  The pattern argument now also accepts the hashcode of a virtual environment instance.
+features:
+  - |
+    Add hashcode to Venv instances for selecting environments.

--- a/riot/cli.py
+++ b/riot/cli.py
@@ -105,7 +105,20 @@ def generate(ctx, recreate_venvs, skip_base_install, pythons, pattern):
 
 
 @main.command(
-    help="""Run virtualenv instances with names matching a pattern.""",
+    help="""Run virtual environment instances.
+
+Instances can be filtered by providing a pattern to match the name or hashcode.
+
+Arguments can be passed to the command of the instance as well.
+
+Examples:
+
+    riot run tests
+
+    riot run tests -k "test_something_specific"
+
+    riot run 9a32b
+""",
     context_settings=dict(ignore_unknown_options=True, allow_extra_args=True),
 )
 @RECREATE_VENVS_ARG

--- a/riot/riot.py
+++ b/riot/riot.py
@@ -70,7 +70,7 @@ class Interpreter:
 
     def __str__(self) -> str:
         """Return the path of the interpreter executable."""
-        return repr(self)
+        return repr(self.path())
 
     def version(self) -> str:
         path = self.path()
@@ -398,7 +398,7 @@ class Session:
             failed = r.code != 0
             status_char = "✖️" if failed else "✔️"
             env_str = env_to_str(r.instance.env)
-            s = f"{status_char}  {r.instance.name}: {env_str} {r.instance.py} {r.pkgstr}"
+            s = f"{status_char}  <{r.instance.name}: {env_str} {r.pkgstr} {r.instance.py}> {r.instance.command}"
             print(s, file=out)
 
         if any(True for r in results if r.code != 0):

--- a/riot/riot.py
+++ b/riot/riot.py
@@ -224,9 +224,9 @@ class Venv:
 @dataclasses.dataclass(eq=True, frozen=True)
 class VenvInstance:
     command: str
-    env: t.Tuple[t.Tuple[str, str]]
+    env: t.Sequence[t.Tuple[str, str]]
     name: t.Optional[str]
-    pkgs: t.Tuple[t.Tuple[str, str]]
+    pkgs: t.Sequence[t.Tuple[str, str]]
     py: Interpreter
 
     def venv_path(self) -> str:

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -1,3 +1,5 @@
+import typing as t
+
 import pytest
 from riot.riot import Interpreter, VenvInstance
 
@@ -17,7 +19,7 @@ from riot.riot import Interpreter, VenvInstance
         ("3", 3, True),
     ],
 )
-def test_interpreter(v1, v2, equal):
+def test_interpreter(v1: t.Union[float, int, str], v2: t.Union[float, int, str], equal: bool) -> None:
     if equal:
         assert Interpreter(v1) == Interpreter(v2)
         assert hash(Interpreter(v1)) == hash(Interpreter(v2))
@@ -32,16 +34,16 @@ def test_interpreter(v1, v2, equal):
     "v1,v2",
     [
         (
-            VenvInstance("name", Interpreter(3.6), "pytest", tuple(), tuple()),
-            VenvInstance("name1", Interpreter(3.6), "pytest", tuple(), tuple()),
+            VenvInstance("pytest", tuple(), "test", tuple(), Interpreter(3.6)),
+            VenvInstance("pytest", tuple(), "test", tuple(), Interpreter(3.9)),
         ),
         (
-            VenvInstance("name", Interpreter(3.6), "pytest", tuple(), tuple()),
-            VenvInstance("name", Interpreter(3.7), "pytest", tuple(), tuple()),
+            VenvInstance("pytest", tuple(), "test", tuple(), Interpreter(3.6)),
+            VenvInstance("pytest", tuple(), "test2", tuple(), Interpreter(3.6)),
         ),
     ],
 )
-def test_instance_hash_neq(v1, v2):
+def test_instance_hash_neq(v1: VenvInstance, v2: VenvInstance) -> None:
     assert v1.humanhash() != v2.humanhash()
 
 
@@ -49,10 +51,10 @@ def test_instance_hash_neq(v1, v2):
     "v1,v2",
     [
         (
-            VenvInstance("name", Interpreter(3.6), "pytest", tuple(), tuple()),
-            VenvInstance("name", Interpreter(3.6), "pytest", tuple(), tuple()),
+            VenvInstance("pytest", tuple(), "test", tuple(), Interpreter(3.6)),
+            VenvInstance("pytest", tuple(), "test", tuple(), Interpreter(3.6)),
         ),
     ],
 )
-def test_instance_hash_eq(v1, v2):
+def test_instance_hash_eq(v1: VenvInstance, v2: VenvInstance) -> None:
     assert v1.humanhash() == v2.humanhash()

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -1,5 +1,5 @@
 import pytest
-from riot.riot import Interpreter
+from riot.riot import Interpreter, VenvInstance
 
 
 @pytest.mark.parametrize(
@@ -26,3 +26,33 @@ def test_interpreter(v1, v2, equal):
         assert Interpreter(v1) != Interpreter(v2)
         assert hash(Interpreter(v1)) != hash(Interpreter(v2))
         assert repr(Interpreter(v1)) != repr(Interpreter(v2))
+
+
+@pytest.mark.parametrize(
+    "v1,v2",
+    [
+        (
+            VenvInstance("name", Interpreter(3.6), "pytest", tuple(), tuple()),
+            VenvInstance("name1", Interpreter(3.6), "pytest", tuple(), tuple()),
+        ),
+        (
+            VenvInstance("name", Interpreter(3.6), "pytest", tuple(), tuple()),
+            VenvInstance("name", Interpreter(3.7), "pytest", tuple(), tuple()),
+        ),
+    ],
+)
+def test_instance_hash_neq(v1, v2):
+    assert v1.humanhash() != v2.humanhash()
+
+
+@pytest.mark.parametrize(
+    "v1,v2",
+    [
+        (
+            VenvInstance("name", Interpreter(3.6), "pytest", tuple(), tuple()),
+            VenvInstance("name", Interpreter(3.6), "pytest", tuple(), tuple()),
+        ),
+    ],
+)
+def test_instance_hash_eq(v1, v2):
+    assert v1.humanhash() == v2.humanhash()

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -19,7 +19,9 @@ from riot.riot import Interpreter, VenvInstance
         ("3", 3, True),
     ],
 )
-def test_interpreter(v1: t.Union[float, int, str], v2: t.Union[float, int, str], equal: bool) -> None:
+def test_interpreter(
+    v1: t.Union[float, int, str], v2: t.Union[float, int, str], equal: bool
+) -> None:
     if equal:
         assert Interpreter(v1) == Interpreter(v2)
         assert hash(Interpreter(v1)) == hash(Interpreter(v2))


### PR DESCRIPTION
VenvInstances now have a hashcode generated with is printed with `riot list`. This hashcode can be used to run specific test with `riot run <hashcode>`.


Along with #89, resolves #24 