### PR TITLE
fix(interpreter): catch the version for Python 2

### DIFF
--- a/riot/riot.py
+++ b/riot/riot.py
@@ -75,7 +75,8 @@ class Interpreter:
     def version(self) -> str:
         path = self.path()
 
-        output = subprocess.check_output([path, "--version"])
+        # Redirect stderr to stdout because Python 2 prints version on stderr
+        output = subprocess.check_output([path, "--version"], stderr=subprocess.STDOUT)
         version = output.decode().strip().split(" ")[1]
         return version
 


### PR DESCRIPTION
Python 2 outputs the version on stderr, not stdout.