### PR TITLE
Add a minimal Mergify configuration

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,0 +1,9 @@
+pull_request_rules:
+  - name: automatic merge
+    conditions:
+      - base=master
+      - label=automerge
+    actions:
+      merge:
+        strict: smart
+        method: merge


### PR DESCRIPTION
This enables automatic merge when the PR matches the branch protection
settings.

The upside of using this is that Mergify will automatically update the pull
request with the base branch before merging. Therefore, we wont't have to press
the `Update branch`, wait for the CI, and then press merge button again to have
a PR that is ready to be merged.

I've added the `automerge` label as a condition for now so we can control the
usage of this feature. Feel free to remove it later when everyone's happy with
this.