### PR TITLE
chore: remove leading dot in venv directory name

### DIFF
--- a/riot/riot.py
+++ b/riot/riot.py
@@ -104,7 +104,7 @@ class Interpreter:
     def venv_path(self) -> str:
         """Return the path to the virtual environment for this interpreter."""
         version = self.version().replace(".", "")
-        return f".riot/.venv_py{version}"
+        return f".riot/venv_py{version}"
 
     def create_venv(self, recreate: bool) -> str:
         """Attempt to create a virtual environment for this intepreter."""


### PR DESCRIPTION
There's no need to hide those since .riot is already hidden.
