### PR TITLE
ci(riot): use Python 3 for non-test env

### DIFF
--- a/riotfile.py
+++ b/riotfile.py
@@ -1,7 +1,7 @@
 from riot import latest, Venv
 
 venv = Venv(
-    pys=3.8,
+    pys=3,
     venvs=[
         Venv(
             name="test",


### PR DESCRIPTION
This allows to run e.g. mypy with Python 3.x, whatever is available.