### PR TITLE
feat: add option to skip missing interpreters

### DIFF
--- a/releasenotes/notes/feature-skip-missing-a032464fbeafdc52.yaml
+++ b/releasenotes/notes/feature-skip-missing-a032464fbeafdc52.yaml
@@ -1,0 +1,5 @@
+---
+features:
+  - |
+    Added the option ``--skip-missing `` to skip runs on missing Python
+    interpreters.

--- a/releasenotes/notes/feature-skip-missing-a032464fbeafdc52.yaml
+++ b/releasenotes/notes/feature-skip-missing-a032464fbeafdc52.yaml
@@ -1,5 +1,5 @@
 ---
 features:
   - |
-    Added the option ``--skip-missing `` to skip runs on missing Python
+    Added the option ``--skip-missing`` to skip runs on missing Python
     interpreters.

--- a/riot/cli.py
+++ b/riot/cli.py
@@ -112,11 +112,19 @@ def generate(ctx, recreate_venvs, skip_base_install, pythons, pattern):
 @SKIP_BASE_INSTALL_ARG
 @click.option("--pass-env", "pass_env", is_flag=True, default=False)
 @PYTHON_VERSIONS_ARG
+@click.option("--skip-missing", "skip_missing", is_flag=True, default=False)
 @PATTERN_ARG
 @VENV_PATTERN_ARG
 @click.pass_context
 def run(
-    ctx, recreate_venvs, skip_base_install, pass_env, pythons, pattern, venv_pattern
+    ctx,
+    recreate_venvs,
+    skip_base_install,
+    pass_env,
+    pythons,
+    skip_missing,
+    pattern,
+    venv_pattern,
 ):
     ctx.obj["session"].run(
         pattern=re.compile(pattern),
@@ -126,4 +134,5 @@ def run(
         pass_env=pass_env,
         cmdargs=ctx.args,
         pythons=pythons,
+        skip_missing=skip_missing,
     )

--- a/riot/riot.py
+++ b/riot/riot.py
@@ -305,6 +305,7 @@ class Session:
         pass_env: bool = False,
         cmdargs: t.Optional[t.Sequence[str]] = None,
         pythons: t.Optional[t.Set[Interpreter]] = None,
+        skip_missing: bool = True,
     ) -> None:
         results = []
 
@@ -322,7 +323,16 @@ class Session:
                 )
                 continue
 
-            base_venv_path: str = inst.py.venv_path()
+            try:
+                base_venv_path: str = inst.py.venv_path()
+            except FileNotFoundError:
+                if skip_missing:
+                    logger.warning("Skipping missing interpreter %s", inst.py)
+                    continue
+                else:
+                    raise
+
+            logger.info("Running with %s", inst.py)
 
             # Resolve the packages required for this instance.
             pkgs: t.Dict[str, str] = {

--- a/riot/riot.py
+++ b/riot/riot.py
@@ -305,7 +305,7 @@ class Session:
         pass_env: bool = False,
         cmdargs: t.Optional[t.Sequence[str]] = None,
         pythons: t.Optional[t.Set[Interpreter]] = None,
-        skip_missing: bool = True,
+        skip_missing: bool = False,
     ) -> None:
         results = []
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -40,6 +40,21 @@ def without_riotfile(
         yield
 
 
+def assert_args(args):
+    assert set(args.keys()) == set(
+        [
+            "pattern",
+            "venv_pattern",
+            "recreate_venvs",
+            "skip_base_install",
+            "pass_env",
+            "cmdargs",
+            "pythons",
+            "skip_missing",
+        ]
+    )
+
+
 def test_main(cli: click.testing.CliRunner) -> None:
     """Running main with no command returns usage."""
     result = cli.invoke(riot.cli.main)
@@ -164,17 +179,7 @@ def test_run(cli: click.testing.CliRunner) -> None:
 
             run.assert_called_once()
             kwargs = run.call_args.kwargs
-            assert set(kwargs.keys()) == set(
-                [
-                    "pattern",
-                    "venv_pattern",
-                    "recreate_venvs",
-                    "skip_base_install",
-                    "pass_env",
-                    "cmdargs",
-                    "pythons",
-                ]
-            )
+            assert_args(kwargs)
             assert kwargs["pattern"].pattern == ".*"
             assert kwargs["venv_pattern"].pattern == ".*"
             assert kwargs["recreate_venvs"] is False
@@ -196,17 +201,7 @@ def test_run_with_long_args(cli: click.testing.CliRunner) -> None:
 
             run.assert_called_once()
             kwargs = run.call_args.kwargs
-            assert set(kwargs.keys()) == set(
-                [
-                    "pattern",
-                    "venv_pattern",
-                    "recreate_venvs",
-                    "skip_base_install",
-                    "pass_env",
-                    "cmdargs",
-                    "pythons",
-                ]
-            )
+            assert_args(kwargs)
             assert kwargs["pattern"].pattern == ".*"
             assert kwargs["venv_pattern"].pattern == ".*"
             assert kwargs["recreate_venvs"] is True
@@ -225,17 +220,7 @@ def test_run_with_short_args(cli: click.testing.CliRunner) -> None:
 
             run.assert_called_once()
             kwargs = run.call_args.kwargs
-            assert set(kwargs.keys()) == set(
-                [
-                    "pattern",
-                    "venv_pattern",
-                    "recreate_venvs",
-                    "skip_base_install",
-                    "pass_env",
-                    "cmdargs",
-                    "pythons",
-                ]
-            )
+            assert_args(kwargs)
             assert kwargs["pattern"].pattern == ".*"
             assert kwargs["venv_pattern"].pattern == ".*"
             assert kwargs["recreate_venvs"] is True
@@ -254,17 +239,7 @@ def test_run_with_pattern(cli: click.testing.CliRunner) -> None:
 
             run.assert_called_once()
             kwargs = run.call_args.kwargs
-            assert set(kwargs.keys()) == set(
-                [
-                    "pattern",
-                    "venv_pattern",
-                    "recreate_venvs",
-                    "skip_base_install",
-                    "pass_env",
-                    "cmdargs",
-                    "pythons",
-                ]
-            )
+            assert_args(kwargs)
             assert kwargs["pattern"].pattern == "^pattern.*"
             assert kwargs["venv_pattern"].pattern == ".*"
             assert kwargs["recreate_venvs"] is False


### PR DESCRIPTION
Added an option to allow riot to ignore any missing requested Python
interpreters.