### PR TITLE
fix(riot): do not copy symlink target

### DIFF
--- a/riot/riot.py
+++ b/riot/riot.py
@@ -382,7 +382,7 @@ class Session:
                         venv_path,
                     )
                     try:
-                        shutil.copytree(base_venv_path, venv_path)
+                        shutil.copytree(base_venv_path, venv_path, symlinks=True)
                     except FileNotFoundError:
                         logger.info("Base virtualenv '%s' does not exist", venv_path)
                         continue


### PR DESCRIPTION
By default, shutil.copytree follows and copy symlinks targets.

Which is exactly not what standard Unix command does.

Well done, Python.