### PR TITLE
Add riot run -x option to exit after first failure

### DIFF
--- a/releasenotes/notes/add-exitfirst-option-to-run-7bd06dedf87c3180.yaml
+++ b/releasenotes/notes/add-exitfirst-option-to-run-7bd06dedf87c3180.yaml
@@ -1,0 +1,5 @@
+---
+features:
+  - |
+    Add new ``riot run -x/--exitfirst`` option to stop executing
+    further test suites after the first one fails.

--- a/riot/cli.py
+++ b/riot/cli.py
@@ -113,6 +113,7 @@ def generate(ctx, recreate_venvs, skip_base_install, pythons, pattern):
 @click.option("--pass-env", "pass_env", is_flag=True, default=False)
 @PYTHON_VERSIONS_ARG
 @click.option("--skip-missing", "skip_missing", is_flag=True, default=False)
+@click.option("--exitfirst", "-x", "exit_first", is_flag=True, default=False)
 @PATTERN_ARG
 @VENV_PATTERN_ARG
 @click.pass_context
@@ -123,6 +124,7 @@ def run(
     pass_env,
     pythons,
     skip_missing,
+    exit_first,
     pattern,
     venv_pattern,
 ):
@@ -135,4 +137,5 @@ def run(
         cmdargs=ctx.args,
         pythons=pythons,
         skip_missing=skip_missing,
+        exit_first=exit_first,
     )

--- a/riot/riot.py
+++ b/riot/riot.py
@@ -320,6 +320,7 @@ class Session:
         cmdargs: t.Optional[t.Sequence[str]] = None,
         pythons: t.Optional[t.Set[Interpreter]] = None,
         skip_missing: bool = False,
+        exit_first: bool = False,
     ) -> None:
         results = []
 
@@ -432,6 +433,8 @@ class Session:
             except CmdFailure as e:
                 result.code = e.code
                 click.echo(click.style(e.msg, fg="red"))
+                if exit_first:
+                    break
             except KeyboardInterrupt:
                 result.code = 1
                 break

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -52,6 +52,7 @@ def assert_args(args):
             "cmdargs",
             "pythons",
             "skip_missing",
+            "exit_first",
         ]
     )
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -186,6 +186,7 @@ def test_run(cli: click.testing.CliRunner) -> None:
             assert kwargs["recreate_venvs"] is False
             assert kwargs["skip_base_install"] is False
             assert kwargs["pass_env"] is False
+            assert kwargs["exit_first"] is False
 
 
 def test_run_with_long_args(cli: click.testing.CliRunner) -> None:
@@ -194,7 +195,13 @@ def test_run_with_long_args(cli: click.testing.CliRunner) -> None:
         with with_riotfile(cli, "empty_riotfile.py"):
             result = cli.invoke(
                 riot.cli.main,
-                ["run", "--recreate-venvs", "--skip-base-install", "--pass-env"],
+                [
+                    "run",
+                    "--recreate-venvs",
+                    "--skip-base-install",
+                    "--pass-env",
+                    "--exitfirst",
+                ],
             )
             # Success, but no output because we mock run
             assert result.exit_code == 0
@@ -208,13 +215,14 @@ def test_run_with_long_args(cli: click.testing.CliRunner) -> None:
             assert kwargs["recreate_venvs"] is True
             assert kwargs["skip_base_install"] is True
             assert kwargs["pass_env"] is True
+            assert kwargs["exit_first"] is True
 
 
 def test_run_with_short_args(cli: click.testing.CliRunner) -> None:
     """Running run with short option names uses those options."""
     with mock.patch("riot.cli.Session.run") as run:
         with with_riotfile(cli, "empty_riotfile.py"):
-            result = cli.invoke(riot.cli.main, ["run", "-r", "-s"])
+            result = cli.invoke(riot.cli.main, ["run", "-r", "-s", "-x"])
             # Success, but no output because we mock run
             assert result.exit_code == 0
             assert result.stdout == ""
@@ -227,6 +235,7 @@ def test_run_with_short_args(cli: click.testing.CliRunner) -> None:
             assert kwargs["recreate_venvs"] is True
             assert kwargs["skip_base_install"] is True
             assert kwargs["pass_env"] is False
+            assert kwargs["exit_first"] is True
 
 
 def test_run_with_pattern(cli: click.testing.CliRunner) -> None:
@@ -246,6 +255,7 @@ def test_run_with_pattern(cli: click.testing.CliRunner) -> None:
             assert kwargs["recreate_venvs"] is False
             assert kwargs["skip_base_install"] is False
             assert kwargs["pass_env"] is False
+            assert kwargs["exit_first"] is False
 
 
 def test_run_no_venv_pattern(cli: click.testing.CliRunner) -> None:


### PR DESCRIPTION
-x/--exitfirst which are the same arguments used by pytest
disabled by default, but if provided will stop executing any further test
suites after the first one fails

resolves #133 