### PR TITLE
use default shell on system

### DIFF
--- a/releasenotes/notes/use-system-shell-222f6711f7b17dd4.yaml
+++ b/releasenotes/notes/use-system-shell-222f6711f7b17dd4.yaml
@@ -1,0 +1,5 @@
+---
+features:
+  - |
+    source the shell from the system's ``SHELL`` environment variable,
+    if that's missing fall back to ``/bin/bash`` as the default shell.

--- a/riot/riot.py
+++ b/riot/riot.py
@@ -15,7 +15,7 @@ import click
 
 logger = logging.getLogger(__name__)
 
-SHELL = "/bin/bash"
+SHELL = os.getenv("SHELL", "/bin/bash")
 ENCODING = sys.getdefaultencoding()
 
 


### PR DESCRIPTION
Update the initialization to accept the default shell set in the system, if that's not found to fall back to `/bin/bash`