### PR TITLE
Add support for CIRCLE_NODE_{TOTAL,INDEX} environment variables

### DIFF
--- a/releasenotes/notes/support-ci-parallelism-1fb4b2ef24b0fe1c.yaml
+++ b/releasenotes/notes/support-ci-parallelism-1fb4b2ef24b0fe1c.yaml
@@ -1,0 +1,8 @@
+---
+features:
+  - |
+    Support CI parallelism  by automatically subdividing selected virtual envs based on
+    ``CI_NODE_TOTAL``/``CI_NODE_INDEX``, or ``CIRCLE_NODE_TOTAL``/``CIRCLE_NODE_INDEX``
+    environment variables if they are available.
+
+    This will impact the results from ``riot run`` and ``riot list``.

--- a/riot/cli.py
+++ b/riot/cli.py
@@ -4,12 +4,10 @@ import logging
 import re
 import sys
 
-
 import click
 import pkg_resources
 
 from .riot import Interpreter, Session
-
 
 try:
     __version__ = pkg_resources.get_distribution("riot").version
@@ -67,7 +65,20 @@ def main(ctx, riotfile, log_level):
         sys.exit(1)
 
 
-@main.command("list", help="""List all virtual env instances matching a pattern.""")
+@main.command(
+    "list",
+    help="""List all virtual env instances matching a pattern.
+
+    **CI parallelism:**
+
+    When using `CircleCI parallelism <https://circleci.com/docs/2.0/parallelism-faster-jobs/>`_
+    ``riot list`` will automatically subdivide venvs based on ``CIRCLE_NODE_TOTAL`` and ``CIRCLE_NODE_INDEX``
+    environment variables.
+
+    For other environments ``riot list`` will automatically subdivide venvs based on ``CI_NODE_TOTAL`` and ``CI_NODE_INDEX``
+    environment variables if they are available.
+""",
+)
 @PYTHON_VERSIONS_ARG
 @PATTERN_ARG
 @VENV_PATTERN_ARG
@@ -105,7 +116,17 @@ def generate(ctx, recreate_venvs, skip_base_install, pythons, pattern):
 
 
 @main.command(
-    help="""Run virtualenv instances with names matching a pattern.""",
+    help="""Run virtualenv instances with names matching a pattern.
+
+    **CI parallelism:**
+
+    When using `CircleCI parallelism <https://circleci.com/docs/2.0/parallelism-faster-jobs/>`_
+    ``riot run`` will automatically subdivide venvs based on ``CIRCLE_NODE_TOTAL`` and ``CIRCLE_NODE_INDEX``
+    environment variables.
+
+    For other environments ``riot run`` will automatically subdivide venvs based on ``CI_NODE_TOTAL`` and ``CI_NODE_INDEX``
+    environment variables if they are available.
+    """,
     context_settings=dict(ignore_unknown_options=True, allow_extra_args=True),
 )
 @RECREATE_VENVS_ARG

--- a/tests/data/many_jobs_riotfile.py
+++ b/tests/data/many_jobs_riotfile.py
@@ -1,0 +1,7 @@
+from riot import Venv
+
+venv = Venv(
+    venvs=[
+        Venv(name="job_{}".format(i), command="exit 0", pys=["3"]) for i in range(15)
+    ]
+)


### PR DESCRIPTION
Fixes #47

I am not convinced having this be the default behavior is the best? Should we require a cli switch to say to use these env variables, or maybe an env variable to disable this behavior?

can we think of a case when someone would not want this? only thing I can think of is if you are using some other tooling to split tests envs that you give to riot, like https://github.com/DataDog/dd-trace-py/blob/8ded786edb6e0b3d7b2e079ae58a0d9ab87ffd05/.circleci/config.yml#L130