### PR TITLE
Add Interpreter.pythonpath and VenvInstance.pythonpath properties

### DIFF
--- a/releasenotes/notes/add-pythonpath-d776c0551e1f22e5.yaml
+++ b/releasenotes/notes/add-pythonpath-d776c0551e1f22e5.yaml
@@ -1,8 +1,6 @@
 ---
 features:
   - |
-    Add ``Interpreter.sitepackages_paths()`` method to get the expected ``site-package`` directories.
-  - |
     Add ``Interpreter.pythonpath`` property to get expected ``PYTHONPATH`` env value for that ``Interpreter``.
   - |
     Add ``VenvInstance.pythonpath`` property to get expected ``PYTHONPATH`` env value for that ``VenvInstance``.

--- a/releasenotes/notes/add-sitepackages-pythonpath-d776c0551e1f22e5.yaml
+++ b/releasenotes/notes/add-sitepackages-pythonpath-d776c0551e1f22e5.yaml
@@ -1,0 +1,8 @@
+---
+features:
+  - |
+    Add ``Interpreter.sitepackages_paths()`` method to get the expected ``site-package`` directories.
+  - |
+    Add ``Interpreter.pythonpath`` property to get expected ``PYTHONPATH`` env value for that ``Interpreter``.
+  - |
+    Add ``VenvInstance.pythonpath`` property to get expected ``PYTHONPATH`` env value for that ``VenvInstance``.

--- a/riot/riot.py
+++ b/riot/riot.py
@@ -100,7 +100,7 @@ class Interpreter:
     @property
     def pythonpath(self) -> str:
         path = self.path()
-        return ":".join(get_python_sitepackages(path)
+        return ":".join(get_python_sitepackages(path))
 
     @functools.lru_cache()
     def path(self) -> str:

--- a/riot/riot.py
+++ b/riot/riot.py
@@ -97,14 +97,10 @@ class Interpreter:
             t.Tuple[int, int, int], tuple(map(int, self.version().split(".")))
         )
 
-    def sitepackages_paths(self) -> t.List[str]:
-        """Return the list of site-packages used by this interpreter."""
-        path = self.path()
-        return get_python_sitepackages(path)
-
     @property
     def pythonpath(self) -> str:
-        return ":".join(self.sitepackages_paths())
+        path = self.path()
+        return ":".join(get_python_sitepackages(path)
 
     @functools.lru_cache()
     def path(self) -> str:

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -72,10 +72,6 @@ def test_get_venv_sitepackages(current_venv: Venv) -> None:
     assert get_venv_sitepackages(instances[0].venv_path()) == site.getsitepackages()
 
 
-def test_interpreter_sitepackages(current_interpreter: Interpreter) -> None:
-    assert current_interpreter.sitepackages_paths() == site.getsitepackages()
-
-
 def test_interpreter_pythonpath(current_interpreter: Interpreter) -> None:
     assert current_interpreter.pythonpath == ":".join(site.getsitepackages())
 

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -1,13 +1,25 @@
+import os
+import re
+import site
 import sys
 
+import mock
 import pytest
-from riot.riot import Interpreter
+from riot.riot import get_python_sitepackages, get_venv_sitepackages, Interpreter, Venv
+
+default_venv_pattern = re.compile(r".*")
+current_py_hint = "%s.%s" % (sys.version_info.major, sys.version_info.minor)
 
 
 @pytest.fixture
 def current_interpreter() -> Interpreter:
-    version = ".".join((str(sys.version_info[0]), str(sys.version_info[1])))
-    return Interpreter(version)
+    return Interpreter(current_py_hint)
+
+
+@pytest.fixture
+def current_venv() -> Venv:
+    # Without a command `.instances()` will not resolve anything
+    return Venv(pys=[current_py_hint], command="echo test")
 
 
 @pytest.mark.parametrize(
@@ -46,8 +58,60 @@ def test_interpreter_version(current_interpreter: Interpreter) -> None:
 
 
 def test_interpreter_version_info(current_interpreter: Interpreter) -> None:
-    assert current_interpreter.version_info() == (
-        sys.version_info[0],
-        sys.version_info[1],
-        sys.version_info[2],
-    )
+    assert current_interpreter.version_info() == sys.version_info[:3]
+
+
+def test_get_python_sitepackages() -> None:
+    assert get_python_sitepackages("python") == site.getsitepackages()
+
+
+@pytest.mark.skip(reason="We are unable to execute venv commands in tests")
+def test_get_venv_sitepackages(current_venv: Venv) -> None:
+    instances = list(current_venv.instances(default_venv_pattern))
+    assert instances
+    assert get_venv_sitepackages(instances[0].venv_path()) == site.getsitepackages()
+
+
+def test_interpreter_sitepackages(current_interpreter: Interpreter) -> None:
+    assert current_interpreter.sitepackages_paths() == site.getsitepackages()
+
+
+def test_interpreter_pythonpath(current_interpreter: Interpreter) -> None:
+    assert current_interpreter.pythonpath == ":".join(site.getsitepackages())
+
+
+def test_venv_instance_pythonpath(current_venv: Venv) -> None:
+    """Test the value of VenvInstance.pythonpath.
+
+    The result from VenvInstance.pythonpath
+      When no VenvInstance.pkgs are defined
+        Will be the Interpreter.pythonpath
+    """
+    instances = list(current_venv.instances(default_venv_pattern))
+    assert instances
+    for instance in instances:
+        assert instance.pythonpath == instance.py.pythonpath
+
+
+def test_venv_instance_with_pkgs_pythonpath(current_venv: Venv) -> None:
+    """Test the value of VenvInstance.pythonpath.
+
+    The result from VenvInstance.pythonpath
+      When there are VenvInstance.pkgs defined
+        Will be the Interpreter.pythonpath + ":" + the virtual envs site-packages
+    """
+    current_venv.pkgs = {"flask": [""]}
+    instances = list(current_venv.instances(default_venv_pattern))
+    assert instances
+    for instance in instances:
+        venv_sitepackages = [
+            os.path.abspath(
+                ".riot/venv_py394_flask/lib/python%s/site-packages" % (current_py_hint,)
+            )
+        ]
+        # We cannot run venv commands in tests, so we have to mock this
+        with mock.patch("riot.riot.get_venv_sitepackages") as m:
+            m.return_value = venv_sitepackages
+
+            expected = ":".join([instance.py.pythonpath] + venv_sitepackages)
+            assert instance.pythonpath == expected


### PR DESCRIPTION
This breaks out the new `Interprter.pythonpath` and `VenvInstance.pythonpath` properties from #132 
