### PR TITLE
Install missing mypy types while type checking

### DIFF
--- a/riotfile.py
+++ b/riotfile.py
@@ -46,7 +46,7 @@ venv = Venv(
         ),
         Venv(
             name="mypy",
-            command="mypy {cmdargs}",
+            command="mypy --install-types --non-interactive {cmdargs}",
             pkgs={
                 "mypy": latest,
                 "pytest": latest,


### PR DESCRIPTION
The latest version of mypy uses modular typesheds. So we need to install the appropriate typeshed for each package we rely on.

This change allows us to automatically install any missing typesheds while processing (it is not two steps, mypy will still produce type checking/errors as part of the result from running with these flags)