### PR TITLE
fix: control and track pip install target dirs

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -4,7 +4,7 @@ exclude=
   .riot,
   .git,
   __pycache__,
-  *.eggs-info,
+  *.eggs*,
   build,
 # Ignore:
 # G201 Logging: .exception(...) should be used instead of .error(..., exc_info=True)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3,7 +3,6 @@ import os
 import shutil
 import typing
 
-
 import _pytest.monkeypatch
 import click.testing
 import mock
@@ -11,7 +10,6 @@ import pytest
 import riot.cli
 import riot.riot
 from riot.riot import Interpreter
-
 
 HERE = os.path.abspath(os.path.dirname(__file__))
 DATA_DIR = os.path.join(HERE, "data")
@@ -69,7 +67,7 @@ def test_list_with_venv_pattern(cli: click.testing.CliRunner) -> None:
                 "pytest543$",
             ],
         )
-        assert result.exit_code == 0
+        assert result.exit_code == 0, result.stdout
         assert result.stdout == "test  Python Interpreter(_hint='3') 'pytest==5.4.3'\n"
 
 

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -48,8 +48,8 @@ def test_interpreter(v1, v2, equal):
 
 def test_interpreter_venv_path(current_interpreter: Interpreter) -> None:
     py_version = "".join((str(_) for _ in sys.version_info[:3]))
-    assert current_interpreter.venv_path() == os.path.join(
-        ".riot", "venv_py{}".format(py_version)
+    assert current_interpreter.venv_path == os.path.abspath(
+        os.path.join(".riot", "venv_py{}".format(py_version))
     )
 
 
@@ -63,7 +63,9 @@ def test_venv_instance_venv_path(current_interpreter: Interpreter) -> None:
     )
 
     py_version = "".join((str(_) for _ in sys.version_info[:3]))
-    assert venv.venv_path() == os.path.join(".riot", "venv_py{}_pip".format(py_version))
+    assert venv.venv_path == os.path.abspath(
+        os.path.join(".riot", "venv_py{}_pip".format(py_version))
+    )
 
 
 def test_interpreter_version(current_interpreter: Interpreter) -> None:


### PR DESCRIPTION
The logic that infers all the venv instances has been reworked to track parenting of venv instances. Installation of packages via pip now happens in a predefined folder. This helps with deriving the elements that need to go to the `PYTHONPATH` and the `PATH` environment to ensure correct layering of re-used intermediate venvs.