### PR TITLE
perf: create base venvs only

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,6 @@ pip-delete-this-directory.txt
 
 # PyBuilder
 target/
+
+# Riot
+.riot/

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -203,9 +203,9 @@ def test_run_venv_pattern(cli: click.testing.CliRunner) -> None:
                 "pytest543$",
             ],
         )
-        assert result.exit_code == 0
+        assert result.exit_code == 0, result.exception
         assert "✓ test:  pythonInterpreter(_hint='3') 'pytest==5.4.3'"
-        assert "1 passed with 0 warnings, 0 failed" in result.stdout
+        assert "1 passed with 0 warnings, 0 failed" in result.stdout, result.stdout
 
 
 def test_generate_suites_with_long_args(cli: click.testing.CliRunner) -> None:
@@ -322,7 +322,7 @@ venv = Venv(
             subprocess_run.assert_called()
 
             cmd = subprocess_run.call_args_list[-1].args[0]
-            assert cmd.endswith(cmdrun)
+            assert cmd.endswith(cmdrun), cmd
 
 
 def test_nested_venv(cli: click.testing.CliRunner) -> None:

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -433,6 +433,7 @@ def test_failure():
 """,
     )
     result = tmp_run("riot run -s pass")
+    assert result.returncode == 0, result.stderr
     assert re.search(
         r"""
 ============================= test session starts ==============================
@@ -448,9 +449,8 @@ test_success.py .*
 ✓ pass: .*
 1 passed with 0 warnings, 0 failed\n""".lstrip(),
         result.stdout,
-    )
+    ), result.stdout
     assert result.stderr == ""
-    assert result.returncode == 0
 
     result = tmp_run("riot run -s fail")
     assert (

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -63,7 +63,7 @@ def test_venv_instance_venv_path(current_interpreter: Interpreter) -> None:
     )
 
     py_version = "".join((str(_) for _ in sys.version_info[:3]))
-    assert venv.venv_path == os.path.abspath(
+    assert venv.prefix == os.path.abspath(
         os.path.join(".riot", "venv_py{}_pip".format(py_version))
     )
 


### PR DESCRIPTION
With control over the pip installation prefix there is no need to create venvs other than the base one. This saves a lot of memory and speeds up the task runs.

These are some numbers based on the `riot` test suite when run with `riot run -p3.9 test`

## Before

`.riot` folder size: 184 MB
test run time: 63 s

## After

`.riot` folder size: 27 MB
test run time: 34 s

## Bonus

`riot list` works 🙂 

~~~
❯ pipenv run riot list     
test  Python Interpreter(_hint='3.6') 'pytest' 'pytest-cov' 'mock' 'typing-extensions'
test  Python Interpreter(_hint='3.7') 'pytest' 'pytest-cov' 'mock' 'typing-extensions'
test  Python Interpreter(_hint='3.8') 'pytest' 'pytest-cov' 'mock' 'typing-extensions'
test  Python Interpreter(_hint='3.9') 'pytest' 'pytest-cov' 'mock' 'typing-extensions'
black  Python Interpreter(_hint='3') 
fmt  Python Interpreter(_hint='3') 
flake8  Python Interpreter(_hint='3') 'flake8' 'flake8-blind-except' 'flake8-builtins' 'flake8-docstrings' 'flake8-import-order' 'flake8-logging-format' 'flake8-rst-docstrings' 'pygments'
mypy  Python Interpreter(_hint='3') 'mypy' 'pytest'
codecov  Python Interpreter(_hint='3') 'coverage'
docs  Python Interpreter(_hint='3') 'sphinx==3.3' 'sphinx-rtd-theme==0.5.0' 'sphinx-click==2.5.0' 'reno'
servedocs  Python Interpreter(_hint='3') 
releasenote  Python Interpreter(_hint='3') 
reno  Python Interpreter(_hint='3')
~~~