### PR TITLE
fix: handling of package installs, env var overrides and namespace packages

### DIFF
--- a/releasenotes/notes/fix-sitepkgs-3ef98bad9dc20f70.yaml
+++ b/releasenotes/notes/fix-sitepkgs-3ef98bad9dc20f70.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    Fixed handling of environment variables, package installations and namespace
+    packages.

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -67,6 +67,8 @@ def test_list_with_venv_pattern(cli: click.testing.CliRunner) -> None:
                 "pytest543$",
             ],
         )
+        if result.exception:
+            raise result.exception
         assert result.exit_code == 0, result.stdout
         assert result.stdout == "test  Python Interpreter(_hint='3') 'pytest==5.4.3'\n"
 
@@ -317,7 +319,7 @@ venv = Venv(
             subprocess_run.return_value.returncode = 0
             args = ["run", name] + cmdargs
             result = cli.invoke(riot.cli.main, args, catch_exceptions=False)
-            assert result.exit_code == 0
+            assert result.exit_code == 0, result.stdout
 
             subprocess_run.assert_called()
 

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -56,9 +56,9 @@ def test_interpreter_venv_path(current_interpreter: Interpreter) -> None:
 def test_venv_instance_venv_path(current_interpreter: Interpreter) -> None:
     venv = VenvInstance(
         command="echo test",
-        env=(("env", "test"),),
+        env={"env": "test"},
         name="test",
-        pkgs=(("pip", ""),),
+        pkgs={"pip": ""},
         py=current_interpreter,
     )
 


### PR DESCRIPTION
With the idea of adding to the `PYTHONPATH`, each venv layer only needs to install its packages inside the venv instance, thus reducing the number of packages that are installed in each venv instance. We still use the full package spec in the result report for easier identification of all the dependencies used.

This change also fixes propagation and override of environment variables across layers as well as the correct handling of namespace packages.

BREAKING CHANGE: this change implies that package declarations that are used for pinning dependencies will have to be added to each venv layer that requires them.