### PR TITLE
fix: use correct interpreter config for venv instance

### DIFF
--- a/releasenotes/notes/fix-parent-py-7de74544797e4d4d.yaml
+++ b/releasenotes/notes/fix-parent-py-7de74544797e4d4d.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Fix handling of interpreter override to avoid repeated command invocations.

--- a/riot/riot.py
+++ b/riot/riot.py
@@ -206,7 +206,6 @@ class Venv:
 
     def instances(
         self,
-        parent: t.Optional["Venv"] = None,
         parent_inst: t.Optional["VenvInstance"] = None,
     ) -> t.Generator["VenvInstance", None, None]:
         # Expand out the instances for the venv.
@@ -216,11 +215,7 @@ class Venv:
             env.update(dict(env_spec))
 
             # Bubble up pys
-            pys = (
-                self.pys
-                or (parent.pys if parent else None)
-                or [parent_inst.py if parent_inst else None]
-            )
+            pys = self.pys or [parent_inst.py if parent_inst else None]
 
             for py in pys:
                 for pkgs in expand_specs(self.pkgs):
@@ -238,7 +233,7 @@ class Venv:
                         yield inst
                     else:
                         for venv in self.venvs:
-                            yield from venv.instances(self, inst)
+                            yield from venv.instances(inst)
 
 
 @dataclasses.dataclass


### PR DESCRIPTION
A venv should take interpreter information from a parent venv instance
if it has no pys override.