### PR TITLE
Quote paths that might contain special chars

### DIFF
--- a/releasenotes/notes/shell-fix-d6fc7eb1127473e6.yaml
+++ b/releasenotes/notes/shell-fix-d6fc7eb1127473e6.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    Fix the handling of package extras in shells where `[` and `]` are used
+    special characters (eg. ``zsh``).

--- a/riot/riot.py
+++ b/riot/riot.py
@@ -481,7 +481,7 @@ class VenvInstance:
             try:
                 Session.run_cmd_venv(
                     venv_path,
-                    f"pip --disable-pip-version-check install --prefix {self.prefix} --no-warn-script-location {pkg_str}",
+                    f"pip --disable-pip-version-check install --prefix '{self.prefix}' --no-warn-script-location {pkg_str}",
                     env=env,
                 )
             except CmdFailure as e:

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -732,3 +732,20 @@ venv = Venv(
     assert f"Running command 'echo $PYTHONPATH' in venv '{venv_path}'"
     assert result.stdout.startswith(":".join(("", str(tmp_path))))
     assert result.returncode == 0
+
+
+def test_extras(tmp_path: pathlib.Path, tmp_run: _T_TmpRun) -> None:
+    rf_path = tmp_path / "riotfile.py"
+    rf_path.write_text(
+        """
+from riot import Venv, latest
+venv = Venv(
+    name="test",
+    pys=["3"],
+    pkgs={"reno[sphinx]": latest},
+    command="python -c 'import reno'",
+)
+""",
+    )
+    result = tmp_run("riot -v run -s test")
+    assert result.returncode == 0


### PR DESCRIPTION
Some the the virtualenv paths generated may include shell special
characters like `[` and `]`. Namely this happens when extras are
provided (eg. `reno[sphinx]`).

This was breaking the virtualenv commands as the shell attempts to
interpret the special characters in the commands. This is fixed by
quoting the strings before we pass them to the shell.

Fixes #148.
