### PR TITLE
fix: add quotes around cmdargs

### DIFF
--- a/releasenotes/notes/fix-spaces-cmdargs-16399f428692f9c4.yaml
+++ b/releasenotes/notes/fix-spaces-cmdargs-16399f428692f9c4.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    It is now possible to pass command line arguments ("cmdargs") that contain
+    spaces. That means command line such as ``riot run foobar -- -k 'not
+    this'`` is now interpolated correctly in the command line.

--- a/riot/riot.py
+++ b/riot/riot.py
@@ -647,7 +647,9 @@ class Session:
                 command = inst.command
                 assert command is not None
                 if cmdargs is not None:
-                    command = command.format(cmdargs=(" ".join(cmdargs))).strip()
+                    command = command.format(
+                        cmdargs=(" ".join(f"'{arg}'" for arg in cmdargs))
+                    ).strip()
                 env_str = "\n".join(f"{k}={v}" for k, v in env.items())
                 logger.info(
                     "Running command '%s' in venv '%s' with environment:\n%s.",

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -276,7 +276,7 @@ def test_generate_base_venvs_with_pattern(cli: click.testing.CliRunner) -> None:
     "name,cmdargs,cmdrun",
     [
         ("test_cmdargs", [], "echo cmdargs="),
-        ("test_cmdargs", ["--", "-k", "filter"], "echo cmdargs=-k filter"),
+        ("test_cmdargs", ["--", "-k", "filter"], "echo cmdargs='-k' 'filter'"),
         ("test_nocmdargs", [], "echo no cmdargs"),
         ("test_nocmdargs", ["--", "-k", "filter"], "echo no cmdargs"),
     ],


### PR DESCRIPTION
This fixes use cases such as:

  riot run foobar -- -k 'not test_foobaz'

for:

  pytest {cmdargs}

Which is broken right now because it turns out to run:

as:

  pytest -k not test_foobaz

This fixes the code by adding '' around each cmdargs item, which turns the
command line into:

  pytest '-k' 'not test_foobaz'

Since this whole string is passed to subprocess with shell=True, we're sure
that shell does not try to interpolate anything.

That sounds safe and neat.
