### PR TITLE
feat: match pattern against VenvInstance name and short hash

### DIFF
--- a/releasenotes/notes/feat-match-short-hash-074e7595ec37967b.yaml
+++ b/releasenotes/notes/feat-match-short-hash-074e7595ec37967b.yaml
@@ -1,0 +1,5 @@
+---
+features:
+  - |
+    Match pattern against ``VenvInstance.name`` and ``VenvInstance.short_hash``.
+    This allows you to ``riot run <hash>`` to run only a specific instance.

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -401,6 +401,17 @@ venv = Venv(
     )
     assert result.returncode == 0
 
+    # Listing by hash works
+    result = tmp_run("riot -P list 144c8c4")
+    assert result.stderr == ""
+    assert re.search(
+        r"""
+\[\#7\]  144c8c4  test2  .* Packages\('pkg1==2.0' 'pkg2==4.0'\)
+""".lstrip(),
+        result.stdout,
+    )
+    assert result.returncode == 0
+
 
 def test_run(tmp_path: pathlib.Path, tmp_run: _T_TmpRun) -> None:
     rf_path = tmp_path / "riotfile.py"
@@ -465,6 +476,30 @@ test_success.py .*
     ), result.stdout
     assert result.stderr == ""
     assert result.returncode == 1
+
+
+def test_run_hash(tmp_path: pathlib.Path, tmp_run: _T_TmpRun) -> None:
+    rf_path = tmp_path / "riotfile.py"
+    rf_path.write_text(
+        """
+from riot import Venv
+venv = Venv(
+    pys=[3],
+    pkgs={
+        "pytest": [""],
+    },
+    venvs=[
+        Venv(
+            name="pass",
+            command="echo pass",
+        ),
+    ],
+)
+""",
+    )
+    # DEV: The hash is consistent as long as no settings change
+    result = tmp_run("riot run -s 163716e")
+    assert result.returncode == 0, result.stderr
 
 
 def test_run_cmdargs(tmp_path: pathlib.Path, tmp_run: _T_TmpRun) -> None:

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -95,3 +95,37 @@ def test_venv_matching(current_interpreter: Interpreter) -> None:
     assert not venv.match_venv_pattern(re.compile("pytest345"))
     assert venv.match_venv_pattern(re.compile("pytest543_pip"))
     assert not venv.match_venv_pattern(re.compile("pip_pytest543"))
+
+
+@pytest.mark.parametrize(
+    "pattern",
+    [
+        # Name
+        "test",
+        "te",
+        ".*st",
+        ".*es.*",
+        "^test",
+        "test$",
+        "^test$",
+        "^(no_match)|(test)$",
+        # Short hash
+        "137331a",
+        ".*733.*",
+        "[0-9]*a",
+        "^137331a",
+        "137331a$",
+        "^137331a$",
+        "^(no_match)|(137331a)$",
+    ],
+)
+def test_venv_name_matching(pattern: str) -> None:
+    venv = VenvInstance(
+        command="echo test",
+        env={"env": "test"},
+        name="test",
+        pkgs={"pip": ""},
+        py=Interpreter("3"),
+    )
+    assert venv.short_hash == "137331a"
+    assert venv.matches_pattern(re.compile(pattern))


### PR DESCRIPTION
This allows you to run or list a specific venv instance.

`riot run <hash>`

Fixes  #24