### PR TITLE
chore: pin click to fix incompatibility

### DIFF
--- a/riotfile.py
+++ b/riotfile.py
@@ -17,6 +17,8 @@ venv = Venv(
         Venv(
             pkgs={
                 "black": "==20.8b1",
+                # See https://github.com/psf/black/issues/2964 for incompatibility with click==8.1.0
+                "click": "<8.1.0",
             },
             venvs=[
                 Venv(


### PR DESCRIPTION
The recently released version of click is incompatible with `black==21.4b2`:

```
Traceback (most recent call last):
  File "/home/circleci/project/.riot/venv_py3912_black214b2_isort/bin/black", line 8, in <module>
    sys.exit(patched_main())
  File "/home/circleci/project/.riot/venv_py3912_black214b2_isort/lib/python3.9/site-packages/black/__init__.py", line 7010, in patched_main
    patch_click()
  File "/home/circleci/project/.riot/venv_py3912_black214b2_isort/lib/python3.9/site-packages/black/__init__.py", line 6999, in patch_click
    from click import _unicodefun  # type: ignore
ImportError: cannot import name '_unicodefun' from 'click' (/home/circleci/project/.riot/venv_py3912_black214b2_isort/lib/python3.9/site-packages/click/__init__.py)
```