### PR TITLE
fix(shell): use correct venv

### DIFF
--- a/releasenotes/notes/fix-shell-use-correct-venv-18f139b392dd26f9.yaml
+++ b/releasenotes/notes/fix-shell-use-correct-venv-18f139b392dd26f9.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    Fixed the shell command to use the correct created virtual environment
+    instead of always defaulting to the base one.

--- a/riot/riot.py
+++ b/riot/riot.py
@@ -873,11 +873,12 @@ class Session:
 
             assert inst.py is not None, inst
             try:
-                venv_path = inst.py.venv_path
+                venv_path = inst.venv_path
             except FileNotFoundError:
                 raise RuntimeError("%s not available" % inst.py)
 
             logger.info("Launching shell inside venv instance %s", inst)
+            logger.debug("Setting venv path to %s", venv_path)
 
             # Generate the environment for the instance.
             if pass_env:
@@ -913,11 +914,17 @@ class Session:
                     )
                     rcfile.flush()
 
-                    w, h = os.get_terminal_size()
+                    try:
+                        w, h = os.get_terminal_size()
+                    except OSError:
+                        w, h = 80, 24
                     c = pexpect.spawn(SHELL, ["-i"], dimensions=(h, w), env=env)
                     c.setecho(False)
                     c.sendline(f"source {rcfile.name}")
-                    c.interact()
+                    try:
+                        c.interact()
+                    except Exception:
+                        pass
                     c.close()
                     sys.exit(c.exitstatus)
 


### PR DESCRIPTION
The shell command defaulted to the base virtual environment. This change ensures that the shell commands activates the corrected created virtual environment.