### PR TITLE
refactor: make Venv a simple class

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -74,7 +74,7 @@ def test_list_with_venv_pattern(cli: click.testing.CliRunner) -> None:
         assert result.exit_code == 0, result.stdout
         assert (
             result.stdout
-            == "[#0]  4375064  test          Interpreter(_hint='3') Packages('pytest==5.4.3')\n"
+            == "[#0]  c396b3d  test          Interpreter(_hint='3') Packages('pytest==5.4.3')\n"
         )
 
 
@@ -506,7 +506,7 @@ def test_success():
     assert os.environ["RIOT"] == "1"
     assert os.environ["RIOT_PYTHON_HINT"] == "Interpreter(_hint='3')"
     assert os.environ["RIOT_PYTHON_VERSION"].startswith("3.")
-    assert os.environ["RIOT_VENV_HASH"] == "f8691e0"
+    assert os.environ["RIOT_VENV_HASH"] == "1ddc9da"
     assert os.environ["RIOT_VENV_IDENT"] == "packaging213"
     assert os.environ["RIOT_VENV_NAME"] == "envtest"
     assert os.environ["RIOT_VENV_PKGS"] == "'packaging>=21.3'"

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -225,7 +225,7 @@ venv = Venv(
     assert result.stderr == ""
     assert (
         result.stdout
-        == "[#0]  1c31170  test          Interpreter(_hint='3') Packages()\n"
+        == "[#0]  1324165  test          Interpreter(_hint='3') Packages()\n"
     )
     assert result.returncode == 0
 
@@ -408,11 +408,11 @@ venv = Venv(
     assert result.returncode == 0
 
     # Listing by hash works
-    result = tmp_run("riot -P list 144c8c4")
+    result = tmp_run("riot -P list dd6501c")
     assert result.stderr == ""
     assert re.search(
         r"""
-\[\#7\]  144c8c4  test2  .* Packages\('pkg1==2.0' 'pkg2==4.0'\)
+\[\#7\]  dd6501c  test2  .* Packages\('pkg1==2.0' 'pkg2==4.0'\)
 """.lstrip(),
         result.stdout,
     )

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -110,13 +110,13 @@ def test_venv_matching(current_interpreter: Interpreter) -> None:
         "^test$",
         "^(no_match)|(test)$",
         # Short hash
-        "137331a",
-        ".*733.*",
-        "[0-9]*a",
-        "^137331a",
-        "137331a$",
-        "^137331a$",
-        "^(no_match)|(137331a)$",
+        "158a715",
+        ".*8a7.*",
+        "[0-9]*5",
+        "^158a715",
+        "158a715$",
+        "^158a715$",
+        "^(no_match)|(158a715)$",
     ],
 )
 def test_venv_name_matching(pattern: str) -> None:
@@ -127,5 +127,5 @@ def test_venv_name_matching(pattern: str) -> None:
         pkgs={"pip": ""},
         py=Interpreter("3"),
     )
-    assert venv.short_hash == "137331a"
+    assert venv.short_hash == "158a715"
     assert venv.matches_pattern(re.compile(pattern))


### PR DESCRIPTION
The release 0.960 of mypy has highlighted a misuse of `InitVar`. This change fixes it by removing the `dataclass` decorator from `Venv` and adding the required boilerplate code for the `__init__` method. The different `__repr__` method that follows from this refactor has caused the short hashes to change and the tests had to be adjusted accordingly.