### PR TITLE
Fix: Ensure a "restart" of virtualenv deleting the old one with recreation option (-r)

### DIFF
--- a/releasenotes/notes/fix-recreate-environment-550de176056a0231.yaml
+++ b/releasenotes/notes/fix-recreate-environment-550de176056a0231.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Ensure a "restart" of virtualenv deleting the old one with recreation option (-r)

--- a/riot/riot.py
+++ b/riot/riot.py
@@ -169,9 +169,7 @@ class Interpreter:
             return venv_path
 
         if recreate:
-            logger.info(
-                "Deleting virtualenv '%s'", venv_path
-            )
+            logger.info("Deleting virtualenv '%s'", venv_path)
             shutil.rmtree(venv_path, ignore_errors=True)
 
         py_ex = self.path()

--- a/riot/riot.py
+++ b/riot/riot.py
@@ -168,6 +168,12 @@ class Interpreter:
             )
             return venv_path
 
+        if recreate:
+            logger.info(
+                "Deleting virtualenv '%s'", venv_path
+            )
+            shutil.rmtree(venv_path, ignore_errors=True)
+
         py_ex = self.path()
         logger.info("Creating virtualenv '%s' with interpreter '%s'.", venv_path, py_ex)
         run_cmd(["virtualenv", f"--python={py_ex}", venv_path], stdout=subprocess.PIPE)

--- a/riot/riot.py
+++ b/riot/riot.py
@@ -163,15 +163,14 @@ class Interpreter:
         """Attempt to create a virtual environment for this intepreter."""
         venv_path: str = path or self.venv_path
 
-        if os.path.isdir(venv_path) and not recreate:
-            logger.info(
-                "Skipping creation of virtualenv '%s' as it already exists.", venv_path
-            )
-            return venv_path
-
-        if recreate:
+        if os.path.isdir(venv_path):
+            if not recreate:
+                logger.info(
+                    "Skipping creation of virtualenv '%s' as it already exists.", venv_path
+                )
+                return venv_path
             logger.info("Deleting virtualenv '%s'", venv_path)
-            shutil.rmtree(venv_path, ignore_errors=True)
+            shutil.rmtree(venv_path)
 
         py_ex = self.path()
         logger.info("Creating virtualenv '%s' with interpreter '%s'.", venv_path, py_ex)

--- a/riot/riot.py
+++ b/riot/riot.py
@@ -191,7 +191,7 @@ class Interpreter:
                     "Skipping creation of virtualenv '%s' as it already exists.",
                     venv_path,
                 )
-                return venv_path
+                return False
             logger.info("Deleting virtualenv '%s'", venv_path)
             shutil.rmtree(venv_path)
 
@@ -879,13 +879,13 @@ class Session:
                 # We check if the venv existed already. If it didn't, we know we
                 # have to install the dev package. Otherwise we assume that it
                 # already has the dev package installed.
-                existed = not py.create_venv(recreate)
+                install_deps = py.create_venv(recreate)
             except CmdFailure as e:
                 logger.error("Failed to create virtual environment.\n%s", e.proc.stdout)
             except FileNotFoundError:
                 logger.error("Python version '%s' not found.", py)
             else:
-                if existed and skip_deps:
+                if not install_deps and skip_deps:
                     logger.info("Skipping global deps install.")
                     continue
 

--- a/riot/riot.py
+++ b/riot/riot.py
@@ -166,7 +166,8 @@ class Interpreter:
         if os.path.isdir(venv_path):
             if not recreate:
                 logger.info(
-                    "Skipping creation of virtualenv '%s' as it already exists.", venv_path
+                    "Skipping creation of virtualenv '%s' as it already exists.",
+                    venv_path,
                 )
                 return venv_path
             logger.info("Deleting virtualenv '%s'", venv_path)

--- a/riot/riot.py
+++ b/riot/riot.py
@@ -156,7 +156,8 @@ class Interpreter:
     def venv_path(self) -> str:
         """Return the path to the virtual environment for this interpreter."""
         version = self.version().replace(".", "")
-        return os.path.abspath(f".riot/venv_py{version}")
+        env_base_path = os.environ.get("RIOT_ENV_BASE_PATH") or ".riot/venv_py"
+        return os.path.abspath(f"{env_base_path}{version}")
 
     def create_venv(self, recreate: bool, path: t.Optional[str] = None) -> str:
         """Attempt to create a virtual environment for this intepreter."""
@@ -511,7 +512,7 @@ class VenvInstance:
             py is not None
             and self.pkgs
             and self.prefix is not None
-            and not os.path.isdir(self.prefix)
+            and (not os.path.isdir(self.prefix) or recreate)
         ):
             venv_path = self.venv_path
             assert venv_path is not None, py

--- a/tests/data/nested_riotfile.py
+++ b/tests/data/nested_riotfile.py
@@ -1,0 +1,48 @@
+from riot import Venv
+
+venv = Venv(
+    name="lvl_1",
+    pkgs={
+        "itsdangerous": "==1.1.0",
+    },
+    env={
+        "ENV_LVL": "1",
+    },
+    venvs=[
+        Venv(
+            pys=["3"],
+            name="lvl_2",
+            create=True,
+            pkgs={
+                "isort": "==5.10.1",
+            },
+            env={
+                "ENV_LVL": "2",
+            },
+            venvs=[
+                Venv(
+                    name="lvl_3_1",
+                    create=True,
+                    pkgs={
+                        "six": "==1.16.0",
+                    },
+                    env={
+                        "ENV_LVL": "3",
+                    },
+                    command="python -c 'print(\"lvl_3_1\")'",
+                ),
+                Venv(
+                    name="lvl_3_2",
+                    create=True,
+                    pkgs={
+                        "six": "==1.15.0",
+                    },
+                    env={
+                        "ENV_LVL": "3",
+                    },
+                    command="python -c 'print(\"lvl_3_2\")'",
+                ),
+            ],
+        )
+    ],
+)

--- a/tests/setup.py
+++ b/tests/setup.py
@@ -1,9 +1,0 @@
-"""
-Setup file for testing purpose.
-
-Session.generate_base_venvs executes `pip ... install -e .` and
-looking for a setup.py or pyproject.toml
-"""
-from setuptools import setup
-
-setup(name="riot_tests")

--- a/tests/setup.py
+++ b/tests/setup.py
@@ -1,0 +1,9 @@
+"""
+Setup file for testing purpose.
+
+Session.generate_base_venvs executes `pip ... install -e .` and
+looking for a setup.py or pyproject.toml
+"""
+from setuptools import setup
+
+setup(name="riot_tests")

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -24,7 +24,9 @@ def current_venv() -> Venv:
 
 
 @pytest.fixture
-def interpreter_virtualenv(current_interpreter: Interpreter) -> Generator[Dict[str, str], None, None]:
+def interpreter_virtualenv(
+    current_interpreter: Interpreter,
+) -> Generator[Dict[str, str], None, None]:
     venv_path = ""
     try:
         # Define env paths and variables

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -176,14 +176,14 @@ def test_interpreter_venv_creation(interpreter_virtualenv: Dict[str, str]) -> No
     venv = interpreter_virtualenv
 
     run_cmd(
-        ["python", "-m", "pip", "install", "itsdangerous==2.1.2"],
+        ["python", "-m", "pip", "install", "itsdangerous==1.1.0"],
         stdout=subprocess.PIPE,
         env=venv,
     )
     result = run_cmd(
         ["python", "-m", "pip", "freeze"], stdout=subprocess.PIPE, env=venv
     )
-    assert result.stdout == "itsdangerous==2.1.2\n"
+    assert result.stdout == "itsdangerous==1.1.0\n"
 
 
 def test_interpreter_venv_recreation(
@@ -192,7 +192,7 @@ def test_interpreter_venv_recreation(
     venv = interpreter_virtualenv
 
     run_cmd(
-        ["python", "-m", "pip", "install", "itsdangerous==2.1.2"],
+        ["python", "-m", "pip", "install", "itsdangerous==1.1.0"],
         stdout=subprocess.PIPE,
         env=venv,
     )

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -54,7 +54,7 @@ def interpreter_virtualenv(
 def session_virtualenv() -> Generator[Session, None, None]:
     try:
         session = Session.from_config_file(os.path.join(DATA_DIR, "nested_riotfile.py"))
-        os.environ["RIOT_ENV_BASE_PATH"] = os.path.join(RIOT_TESTS_PATH, "venv_py")
+        os.environ["RIOT_ENV_BASE_PATH"] = RIOT_TESTS_PATH
 
         session.generate_base_venvs(re.compile(""), True, False, set())
         yield session
@@ -71,6 +71,7 @@ def _get_env(env_name: str) -> Dict[str, str]:
 
     venv_python_path = os.path.join(venv_path, "bin")
     command_env = {
+        "RIOT_ENV_BASE_PATH": RIOT_TESTS_PATH,
         "PYTHONPATH": venv_python_path,
         "PATH": venv_python_path + ":" + venv_site_packages_path,
         "VENV_PATH": venv_path,

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -6,8 +6,11 @@ import sys
 from typing import Dict, Generator
 
 import pytest
-from riot.riot import Interpreter, run_cmd, Venv, VenvInstance
+from riot.riot import Interpreter, run_cmd, Session, Venv, VenvInstance
+from tests.test_cli import DATA_DIR
 
+
+RIOT_TESTS_PATH = os.path.join(os.path.dirname(__file__), ".riot")
 default_venv_pattern = re.compile(r".*")
 current_py_hint = "%s.%s" % (sys.version_info.major, sys.version_info.minor)
 
@@ -27,38 +30,69 @@ def current_venv() -> Venv:
 def interpreter_virtualenv(
     current_interpreter: Interpreter,
 ) -> Generator[Dict[str, str], None, None]:
-    venv_path = ""
     try:
-        # Define env paths and variables
         env_name = "test_interpreter_venv_creation"
-        venv_path = os.path.abspath(os.path.join(".riot", env_name))
-        venv_site_packages_path = os.path.abspath(
-            os.path.join(venv_path, "lib", "python3.8", "site-packages")
-        )
-        venv_python_path = os.path.join(venv_path, "bin")
-        command_env = {
-            "PYTHONPATH": venv_python_path,
-            "PATH": venv_python_path + ":" + venv_site_packages_path,
-            "VENV_PATH": venv_path,
-        }
+        command_env = _get_env(env_name)
 
         # Create the virtualenv
-        current_interpreter.create_venv(recreate=True, path=str(venv_path))
-
-        # Check exists and is empty of packages
-        result = run_cmd(
-            ["python", "-m", "pip", "freeze"], stdout=subprocess.PIPE, env=command_env
+        current_interpreter.create_venv(
+            recreate=True, path=command_env["VENV_PATH"]
         )
-        assert os.path.isdir(venv_path)
-        assert result.stdout == ""
 
-        # return the cmmand environment to reuse in other commands
+        # Check folder exists and is empty of packages
+        result = _get_pip_freeze(command_env)
+        assert os.path.isdir(command_env["VENV_PATH"])
+        assert result == ""
+
+        # return the command environment to reuse in other commands
         yield command_env
 
-        assert os.path.isdir(venv_path)
+        assert os.path.isdir(command_env["VENV_PATH"])
     finally:
-        if venv_path:
-            shutil.rmtree(venv_path, ignore_errors=True)
+        shutil.rmtree(RIOT_TESTS_PATH, ignore_errors=True)
+
+
+@pytest.fixture
+def session_virtualenv() -> Generator[Session, None, None]:
+    try:
+        session = Session.from_config_file(os.path.join(DATA_DIR, "nested_riotfile.py"))
+        os.environ["RIOT_ENV_BASE_PATH"] = os.path.join(RIOT_TESTS_PATH, "venv_py")
+
+        session.generate_base_venvs(re.compile(""), True, False, set())
+        yield session
+    finally:
+        shutil.rmtree(RIOT_TESTS_PATH, ignore_errors=True)
+
+
+def _get_env(env_name: str) -> Dict[str, str]:
+    """Return a dictionary with riot venv paths to add to the environment."""
+    venv_path = os.path.join(RIOT_TESTS_PATH, env_name)
+    venv_site_packages_path = os.path.join(
+        venv_path, "lib", f"python{current_py_hint}", "site-packages"
+    )
+
+    venv_python_path = os.path.join(venv_path, "bin")
+    command_env = {
+        "PYTHONPATH": venv_python_path,
+        "PATH": venv_python_path + ":" + venv_site_packages_path,
+        "VENV_PATH": venv_path,
+    }
+    return command_env
+
+
+def _get_pip_freeze(venv: Dict[str, str]) -> str:
+    result = run_cmd(
+        ["python", "-m", "pip", "freeze"], stdout=subprocess.PIPE, env=venv
+    )
+    return result.stdout
+
+
+def _run_pip_install(package: str, venv: Dict[str, str]) -> None:
+    run_cmd(
+        ["python", "-m", "pip", "install", package],
+        stdout=subprocess.PIPE,
+        env=venv,
+    )
 
 
 @pytest.mark.parametrize(
@@ -172,34 +206,143 @@ def test_venv_name_matching(pattern: str) -> None:
     assert venv.matches_pattern(re.compile(pattern))
 
 
-def test_interpreter_venv_creation(interpreter_virtualenv: Dict[str, str]) -> None:
-    venv = interpreter_virtualenv
+def test_interpreter_venv_creation(
+    current_interpreter: Interpreter, interpreter_virtualenv: Dict[str, str]
+) -> None:
+    """Validate interpreter, creation of virtualenv.
 
-    run_cmd(
-        ["python", "-m", "pip", "install", "itsdangerous==1.1.0"],
-        stdout=subprocess.PIPE,
-        env=venv,
-    )
-    result = run_cmd(
-        ["python", "-m", "pip", "freeze"], stdout=subprocess.PIPE, env=venv
-    )
-    assert result.stdout == "itsdangerous==1.1.0\n"
+    Install a package with pip in interpreter virtualenv and validate
+    if we re-run create_venv with recreate equal to False, the dependencies aren't
+    override
+    """
+    venv = interpreter_virtualenv
+    python_package = "itsdangerous==1.1.0"
+    _run_pip_install(python_package, venv)
+
+    current_interpreter.create_venv(recreate=False, path=str(venv["VENV_PATH"]))
+
+    result = _get_pip_freeze(venv)
+    assert result == "{}\n".format(python_package)
 
 
 def test_interpreter_venv_recreation(
     current_interpreter: Interpreter, interpreter_virtualenv: Dict[str, str]
 ) -> None:
+    """Validate interpreter, recreation of virtualenv.
+
+    Install a package with pip in interpreter virtualenv and validate
+    if we re-run create_venv with recreate equal to True, the dependencies are restored.
+    """
     venv = interpreter_virtualenv
 
-    run_cmd(
-        ["python", "-m", "pip", "install", "itsdangerous==1.1.0"],
-        stdout=subprocess.PIPE,
-        env=venv,
-    )
+    python_package = "itsdangerous==1.1.0"
+    _run_pip_install(python_package, venv)
 
     current_interpreter.create_venv(recreate=True, path=str(venv["VENV_PATH"]))
 
-    result = run_cmd(
-        ["python", "-m", "pip", "freeze"], stdout=subprocess.PIPE, env=venv
+    result = _get_pip_freeze(venv)
+    assert result == ""
+
+
+def _get_base_env_path() -> str:
+    return os.path.abspath(
+        os.path.join(
+            RIOT_TESTS_PATH,
+            "venv_py{}{}{}".format(
+                sys.version_info.major,
+                sys.version_info.minor,
+                sys.version_info.micro,
+            ),
+        )
     )
-    assert result.stdout == ""
+
+
+def test_session_generate(session_virtualenv: Session) -> None:
+    """Validate session, generation of virtualenvs.
+
+    Generate new base venv and validate the virtualenv exists
+    """
+    venv_path = _get_base_env_path()
+    assert os.path.isdir(venv_path)
+
+
+def test_session_run(session_virtualenv: Session) -> None:
+    """Validate session run method.
+
+    Generate new base venv and validate the nested packages.
+    """
+    session_virtualenv.run(re.compile(""), re.compile(""), False, False)
+
+    env_name = "venv_py%s%s%s_six1150_isort5101_itsdangerous110" % sys.version_info[:3]
+    command_env = _get_env(env_name)
+    # Check exists and is empty of packages
+    result = _get_pip_freeze(command_env)
+    regex = r"isort==5\.10\.1itsdangerous==1\.1\.0(.*)six==1\.15\.0"
+    expected = re.match(regex, result.replace("\n", ""))
+    assert expected
+
+
+def test_session_run_check_environment_modifications(
+    session_virtualenv: Session,
+) -> None:
+    """Validate session run method.
+
+    Generate new base venv, edit the packages installed with pip isntall
+    and validate the nested packages are different.
+    """
+    session_virtualenv.run(re.compile(""), re.compile(""), False, False)
+
+    env_name = "venv_py%s%s%s_six1150_isort5101_itsdangerous110" % sys.version_info[:3]
+    command_env = _get_env(env_name)
+    _run_pip_install("itsdangerous==0.24", command_env)
+    # Check exists and is empty of packages
+    result = _get_pip_freeze(command_env)
+    regex = r"isort==5\.10\.1itsdangerous==0\.24(.*)six==1\.15\.0"
+    expected = re.match(regex, result.replace("\n", ""))
+    assert expected
+
+
+def test_session_run_check_environment_modifications_and_recreate_false(
+    session_virtualenv: Session,
+) -> None:
+    """Validate session run method.
+
+    Create nested environments, edit the packages installed with pip isntall
+    and validate the nested packages are different after execute again session.run
+    with recreate_venvs equal to False.
+    """
+    session_virtualenv.run(re.compile(""), re.compile(""), False, False)
+
+    env_name = "venv_py%s%s%s_six1150_isort5101_itsdangerous110" % sys.version_info[:3]
+    command_env = _get_env(env_name)
+    _run_pip_install("itsdangerous==0.24", command_env)
+
+    session_virtualenv.run(re.compile(""), re.compile(""), False, False)
+
+    result = _get_pip_freeze(command_env)
+    regex = r"isort==5\.10\.1itsdangerous==0\.24(.*)six==1\.15\.0"
+    expected = re.match(regex, result.replace("\n", ""))
+    assert expected
+
+
+def test_session_run_check_environment_modifications_and_recreate_true(
+    session_virtualenv: Session,
+) -> None:
+    """Validate session run method.
+
+    Create nested environments, edit the packages installed with pip isntall
+    and validate the nested packages are restored after execute again session.run
+    with recreate_venvs equal to True.
+    """
+    session_virtualenv.run(re.compile(""), re.compile(""), False, False)
+
+    env_name = "venv_py%s%s%s_six1150_isort5101_itsdangerous110" % sys.version_info[:3]
+    command_env = _get_env(env_name)
+    _run_pip_install("itsdangerous==0.24", command_env)
+
+    session_virtualenv.run(re.compile(""), re.compile(""), False, True)
+
+    result = _get_pip_freeze(command_env)
+    regex = r"isort==5\.10\.1itsdangerous==1\.1\.0(.*)six==1\.15\.0"
+    expected = re.match(regex, result.replace("\n", ""))
+    assert expected, "error: {}".format(result)

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -35,9 +35,7 @@ def interpreter_virtualenv(
         command_env = _get_env(env_name)
 
         # Create the virtualenv
-        current_interpreter.create_venv(
-            recreate=True, path=command_env["VENV_PATH"]
-        )
+        current_interpreter.create_venv(recreate=True, path=command_env["VENV_PATH"])
 
         # Check folder exists and is empty of packages
         result = _get_pip_freeze(command_env)


### PR DESCRIPTION
# Description
`riot` runs `virtualenv [directory]` to create a virtualenv. If `venv 01` directory exists and you run `virtualenv venv01`, the old virtualenv still has the same packages with no reset.


## Manually test
```
# Create a new virtualenv
python3.8 -m virtualenv -p38 venv_test_38
source venv_test_38/bin/activate 
pip install flask
deactivate

# Recreate
python3.8 -m virtualenv -p38 venv_test_38
source venv_test_38/bin/activate 
pip freeze
```
Output:

```
click==8.1.3
Flask==2.1.3
importlib-metadata==4.12.0
itsdangerous==2.1.2
Jinja2==3.1.2
MarkupSafe==2.1.1
Werkzeug==2.1.2
zipp==3.8.1
```
