### PR TITLE
refactor!: ensure dev package is installed in base venv

### DIFF
--- a/releasenotes/notes/refactor-ensure-dev-in-base-b9c2a3d23d742851.yaml
+++ b/releasenotes/notes/refactor-ensure-dev-in-base-b9c2a3d23d742851.yaml
@@ -1,0 +1,10 @@
+---
+features:
+  - |
+    Riot can now be used to run commands in virtual environments even when a
+    Python setup file is not available in the working directory. A warning will
+    be issued in these cases instead.
+fixes:
+  - |
+    Ensure that the dev package is always installed in the base environment when
+    it is created for the first time, if any exist.

--- a/riot/riot.py
+++ b/riot/riot.py
@@ -158,20 +158,29 @@ class Interpreter:
         version = self.version().replace(".", "")
         return os.path.abspath(f".riot/venv_py{version}")
 
-    def create_venv(self, recreate: bool, path: t.Optional[str] = None) -> str:
-        """Attempt to create a virtual environment for this intepreter."""
+    def exists(self) -> bool:
+        """Return whether the virtual environment for this interpreter exists."""
+        return os.path.isdir(self.venv_path)
+
+    def create_venv(self, recreate: bool, path: t.Optional[str] = None) -> bool:
+        """Attempt to create a virtual environment for this intepreter.
+
+        Returns ``True`` if the virtual environment was created or ``False`` if
+        it already existed.
+        """
         venv_path: str = path or self.venv_path
 
         if os.path.isdir(venv_path) and not recreate:
             logger.info(
                 "Skipping creation of virtualenv '%s' as it already exists.", venv_path
             )
-            return venv_path
+            return False
 
         py_ex = self.path()
         logger.info("Creating virtualenv '%s' with interpreter '%s'.", venv_path, py_ex)
         run_cmd(["virtualenv", f"--python={py_ex}", venv_path], stdout=subprocess.PIPE)
-        return venv_path
+
+        return True
 
 
 @dataclasses.dataclass
@@ -848,18 +857,21 @@ class Session:
 
         for py in required_pys:
             try:
-                venv_path = py.create_venv(recreate)
+                # We check if the venv existed already. If it didn't, we know we
+                # have to install the dev package. Otherwise we assume that it
+                # already has the dev package installed.
+                existed = not py.create_venv(recreate)
             except CmdFailure as e:
                 logger.error("Failed to create virtual environment.\n%s", e.proc.stdout)
             except FileNotFoundError:
                 logger.error("Python version '%s' not found.", py)
             else:
-                if skip_deps:
+                if existed and skip_deps:
                     logger.info("Skipping global deps install.")
                     continue
 
                 # Install the dev package into the base venv.
-                install_dev_pkg(venv_path)
+                install_dev_pkg(py.venv_path)
 
     def _generate_shell_rcfile(self):
         with tempfile.NamedTemporaryFile() as rcfile:
@@ -1052,6 +1064,13 @@ def pip_deps(pkgs: t.Dict[str, str]) -> str:
 
 
 def install_dev_pkg(venv_path):
+    for setup_file in {"setup.py", "pyproject.toml"}:
+        if os.path.exists(setup_file):
+            break
+    else:
+        logger.warning("No Python setup file found. Skipping dev package installation.")
+        return
+
     logger.info("Installing dev package (edit mode) in %s.", venv_path)
     try:
         Session.run_cmd_venv(

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -456,7 +456,7 @@ def test_failure():
     assert 1 == 0
 """,
     )
-    result = tmp_run("riot run -s pass")
+    result = tmp_run("riot --pipe run -s pass")
     assert result.returncode == 0, result.stderr
     assert re.search(
         r"""
@@ -474,7 +474,10 @@ test_success.py .*
 1 passed with 0 warnings, 0 failed\n""".lstrip(),
         result.stdout,
     ), result.stdout
-    assert result.stderr == ""
+    assert (
+        "No Python setup file found. Skipping dev package installation."
+        in result.stderr
+    )
 
     result = tmp_run("riot run -s fail")
     assert re.search(
@@ -522,9 +525,12 @@ venv = Venv(
 )
 """,
     )
-    result = tmp_run("riot run -s test_cmdargs -- -k filter")
+    result = tmp_run("riot --pipe run -s test_cmdargs -- -k filter")
     assert "cmdargs=-k filter" not in result.stdout
-    assert result.stderr == ""
+    assert (
+        "No Python setup file found. Skipping dev package installation."
+        in result.stderr
+    )
     assert result.returncode == 0
 
     rf_path.write_text(
@@ -555,10 +561,12 @@ venv = Venv(
 )
 """,
     )
-    result = tmp_run("riot run test")
-    assert result.returncode == 1
-    assert "setup.py" in result.stderr, result.stderr
-    assert "Dev install failed, aborting!" in result.stderr, result.stderr
+    result = tmp_run("riot --pipe run test")
+    assert result.returncode == 0
+    assert (
+        "No Python setup file found. Skipping dev package installation."
+        in result.stderr
+    )
 
 
 def test_bad_interpreter(tmp_path: pathlib.Path, tmp_run: _T_TmpRun) -> None:


### PR DESCRIPTION
When running a command for the first time with the `-s` option, the base virtual environments get created, but the installation of the dev package is skipped. This results in import errors when running Python commands against the dev package. This change modified the behaviour of `riot` to ensure that the dev package is always installed when the base virtual environments are generated for the first time. If no dev package is present in the working directory, a warning is issued instead of an error to allow running generic commands without the use of the `-s` option.