### PR TITLE
fix: use path to actual Python binary

### DIFF
--- a/releasenotes/notes/fix-use-actual-binary-path-dea292c916d915e5.yaml
+++ b/releasenotes/notes/fix-use-actual-binary-path-dea292c916d915e5.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    Riot will now use the path of the actual discovered Python binary to create
+    virtual environments, instead of using wrapping shell scripts (e.g. pyenv
+    shims).

--- a/riot/riot.py
+++ b/riot/riot.py
@@ -148,7 +148,16 @@ class Interpreter:
             py_ex = shutil.which(f"python{self._hint}")
 
         if py_ex:
-            return os.path.abspath(py_ex)
+            # Ensure that we are getting the path of the actual executable,
+            # rather than some wrapping shell script.
+
+            return os.path.abspath(
+                subprocess.check_output(
+                    [py_ex, "-c", "import sys;print(sys.executable)"]
+                )
+                .decode()
+                .strip()
+            )
 
         raise FileNotFoundError(f"Python interpreter {self._hint} not found")
 


### PR DESCRIPTION
This change ensures that virtual environments are created with the actual Python binary instead of passing the path to a wrapping script which could cause the creation of inconsistent virtual environments.