### PR TITLE
fix(flake8): new release 5.0 introduces errors in plugins

### DIFF
--- a/riotfile.py
+++ b/riotfile.py
@@ -35,7 +35,7 @@ venv = Venv(
             name="flake8",
             command="flake8 {cmdargs}",
             pkgs={
-                "flake8": latest,
+                "flake8": "<5.0.0",
                 "flake8-blind-except": latest,
                 "flake8-builtins": latest,
                 "flake8-docstrings": latest,


### PR DESCRIPTION
Set [flake8 version (<5.0.0)](https://pypi.org/project/flake8/#history) until flake8 plugins update their code: https://github.com/pycqa/flake8/issues/325