### PR TITLE
test: run tests in parallel

### DIFF
--- a/riotfile.py
+++ b/riotfile.py
@@ -5,11 +5,12 @@ venv = Venv(
     venvs=[
         Venv(
             name="test",
-            command="pytest {cmdargs}",
+            command="pytest -n auto --dist loadscope {cmdargs}",
             pys=["3.6", "3.7", "3.8", "3.9", "3.10"],
             pkgs={
                 "pytest": latest,
                 "pytest-cov": latest,
+                "pytest-xdist": latest,
                 "mock": latest,
                 "typing-extensions": latest,
             },


### PR DESCRIPTION
This change adds pytest-xdist to the test riot command to run tests in parallel, based on load scope.