### PR TITLE
feat: re-instal dev package on setup file changes

### DIFF
--- a/releasenotes/notes/feat-reinstall-on-setup-hash-change-4bfc854dcc76c49c.yaml
+++ b/releasenotes/notes/feat-reinstall-on-setup-hash-change-4bfc854dcc76c49c.yaml
@@ -1,0 +1,5 @@
+---
+features:
+  - |
+    Riot will attempt to re-install the development package if changes to the
+    setup files are detected when using the skip option with the run command.


### PR DESCRIPTION
This change enables tracking changes in setup files so that the dev package can be re-installed if needed, when the -s option is passed to the run command.