### PR TITLE
feat: add interpreters flag to riot list command

### DIFF
--- a/releasenotes/notes/feat-interpreters-only-flag-for-riot-list-908cc21e85f730b3.yaml
+++ b/releasenotes/notes/feat-interpreters-only-flag-for-riot-list-908cc21e85f730b3.yaml
@@ -1,5 +1,5 @@
 ---
 features:
   - |
-    An interpreters-only flag has been added to the riot list command, which will output a list containing 
-    only the unique python versions corresponding to each matching riot venv instead of a table.
+    An interpreters flag has been added to the riot list command, which will output a list containing 
+    the unique python versions corresponding to each matching riot venv.

--- a/releasenotes/notes/feat-interpreters-only-flag-for-riot-list-908cc21e85f730b3.yaml
+++ b/releasenotes/notes/feat-interpreters-only-flag-for-riot-list-908cc21e85f730b3.yaml
@@ -1,0 +1,5 @@
+---
+features:
+  - |
+    An interpreters-only flag has been added to the riot list command, which will output a list containing 
+    only the unique python versions corresponding to each matching riot venv instead of a table.

--- a/releasenotes/notes/feat-interpreters-only-flag-for-riot-list-908cc21e85f730b3.yaml
+++ b/releasenotes/notes/feat-interpreters-only-flag-for-riot-list-908cc21e85f730b3.yaml
@@ -1,5 +1,5 @@
 ---
 features:
   - |
-    An interpreters flag has been added to the riot list command, which will output a list containing 
+    A ``--interpreters`` flag has been added to the riot list command, which will output a list containing 
     the unique python versions corresponding to each matching riot venv.

--- a/riot/cli.py
+++ b/riot/cli.py
@@ -44,7 +44,11 @@ PYTHON_VERSIONS_ARG = click.option(
     "-p", "--python", "pythons", type=InterpreterParamType(), default=[], multiple=True
 )
 INTERPRETERS_ARG = click.option(
-    "-i", "--interpreters", "interpreters", is_flag=True, default=False,
+    "-i",
+    "--interpreters",
+    "interpreters",
+    is_flag=True,
+    default=False,
 )
 
 

--- a/riot/cli.py
+++ b/riot/cli.py
@@ -43,6 +43,9 @@ SKIP_BASE_INSTALL_ARG = click.option(
 PYTHON_VERSIONS_ARG = click.option(
     "-p", "--python", "pythons", type=InterpreterParamType(), default=[], multiple=True
 )
+INTERPRETERS_ONLY_ARG = click.option(
+    "-i", "--interpreters-only", "interpreters_only", is_flag=True, default=False,
+)
 
 
 @click.group()
@@ -91,13 +94,15 @@ def main(ctx, riotfile, log_level, pipe_mode):
 @PYTHON_VERSIONS_ARG
 @PATTERN_ARG
 @VENV_PATTERN_ARG
+@INTERPRETERS_ONLY_ARG
 @click.pass_context
-def list_venvs(ctx, pythons, pattern, venv_pattern):
+def list_venvs(ctx, pythons, pattern, venv_pattern, interpreters_only):
     ctx.obj["session"].list_venvs(
         re.compile(pattern),
         re.compile(venv_pattern),
         pythons=pythons,
         pipe_mode=ctx.obj["pipe"],
+        interpreters_only=interpreters_only,
     )
 
 

--- a/riot/cli.py
+++ b/riot/cli.py
@@ -43,8 +43,8 @@ SKIP_BASE_INSTALL_ARG = click.option(
 PYTHON_VERSIONS_ARG = click.option(
     "-p", "--python", "pythons", type=InterpreterParamType(), default=[], multiple=True
 )
-INTERPRETERS_ONLY_ARG = click.option(
-    "-i", "--interpreters-only", "interpreters_only", is_flag=True, default=False,
+INTERPRETERS_ARG = click.option(
+    "-i", "--interpreters", "interpreters", is_flag=True, default=False,
 )
 
 
@@ -94,15 +94,15 @@ def main(ctx, riotfile, log_level, pipe_mode):
 @PYTHON_VERSIONS_ARG
 @PATTERN_ARG
 @VENV_PATTERN_ARG
-@INTERPRETERS_ONLY_ARG
+@INTERPRETERS_ARG
 @click.pass_context
-def list_venvs(ctx, pythons, pattern, venv_pattern, interpreters_only):
+def list_venvs(ctx, pythons, pattern, venv_pattern, interpreters):
     ctx.obj["session"].list_venvs(
         re.compile(pattern),
         re.compile(venv_pattern),
         pythons=pythons,
         pipe_mode=ctx.obj["pipe"],
-        interpreters_only=interpreters_only,
+        interpreters=interpreters,
     )
 
 

--- a/riot/riot.py
+++ b/riot/riot.py
@@ -806,11 +806,11 @@ class Session:
             sys.exit(1)
 
     def list_venvs(
-        self, pattern, venv_pattern, pythons=None, out=sys.stdout, pipe_mode=False, interpreters_only=False,
+        self, pattern, venv_pattern, pythons=None, out=sys.stdout, pipe_mode=False, interpreters=False,
     ):
-        interpreters = set()
+        python_interpreters = set()
         table = None
-        if not (pipe_mode or interpreters_only):
+        if not (pipe_mode or interpreters):
             table = Table(
                 "No.",
                 "Hash",
@@ -832,8 +832,8 @@ class Session:
                 continue
             pkgs_str = inst.full_pkg_str
             env_str = env_to_str(inst.env)
-            if interpreters_only:
-                interpreters.add(inst.py._hint)
+            if interpreters:
+                python_interpreters.add(inst.py._hint)
                 continue
             if pipe_mode:
                 print(
@@ -852,8 +852,8 @@ class Session:
         if table:
             rich_print(table)
 
-        if interpreters_only and interpreters:
-            print(",".join(interpreters))
+        if interpreters and python_interpreters:
+            print(",".join(python_interpreters))
 
     def generate_base_venvs(
         self,

--- a/riot/riot.py
+++ b/riot/riot.py
@@ -806,7 +806,13 @@ class Session:
             sys.exit(1)
 
     def list_venvs(
-        self, pattern, venv_pattern, pythons=None, out=sys.stdout, pipe_mode=False, interpreters=False,
+        self,
+        pattern,
+        venv_pattern,
+        pythons=None,
+        out=sys.stdout,
+        pipe_mode=False,
+        interpreters=False,
     ):
         python_interpreters = set()
         table = None

--- a/riot/riot.py
+++ b/riot/riot.py
@@ -806,10 +806,11 @@ class Session:
             sys.exit(1)
 
     def list_venvs(
-        self, pattern, venv_pattern, pythons=None, out=sys.stdout, pipe_mode=False
+        self, pattern, venv_pattern, pythons=None, out=sys.stdout, pipe_mode=False, interpreters_only=False,
     ):
+        interpreters = set()
         table = None
-        if not pipe_mode:
+        if not (pipe_mode or interpreters_only):
             table = Table(
                 "No.",
                 "Hash",
@@ -831,6 +832,9 @@ class Session:
                 continue
             pkgs_str = inst.full_pkg_str
             env_str = env_to_str(inst.env)
+            if interpreters_only:
+                interpreters.add(inst.py._hint)
+                continue
             if pipe_mode:
                 print(
                     f"[#{n}]  {inst.short_hash}  {inst.name:12} {env_str} {inst.py} Packages({pkgs_str})"
@@ -847,6 +851,9 @@ class Session:
 
         if table:
             rich_print(table)
+
+        if interpreters_only and interpreters:
+            print(",".join(interpreters))
 
     def generate_base_venvs(
         self,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -123,6 +123,7 @@ def test_list_with_interpreters_only(cli: click.testing.CliRunner) -> None:
         assert result.exit_code == 0, result.stdout
         assert result.stdout == "3\n"
 
+
 def test_run_with_long_args(cli: click.testing.CliRunner) -> None:
     """Running run with long option names uses those options."""
     with mock.patch("riot.cli.Session.run") as run:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -110,15 +110,15 @@ def test_list_with_python(cli: click.testing.CliRunner) -> None:
 
 
 def test_list_with_interpreters_only(cli: click.testing.CliRunner) -> None:
-    """Running list with --interpreters-only should print only unique Python interpreter versions for matching venvs."""
+    """Running list with --interpreters should print unique Python interpreter versions for matching venvs."""
     with with_riotfile(cli, "empty_riotfile.py"):
-        result = cli.invoke(riot.cli.main, ["list", "--interpreters-only"])
+        result = cli.invoke(riot.cli.main, ["list", "--interpreters"])
         # Success, but no output because no venvs to list
         assert result.exit_code == 0
         assert result.stdout == ""
 
     with with_riotfile(cli, "simple_riotfile.py"):
-        result = cli.invoke(riot.cli.main, ["list", "--interpreters-only"])
+        result = cli.invoke(riot.cli.main, ["list", "--interpreters"])
         # Success, should list 2 venvs with py=3
         assert result.exit_code == 0, result.stdout
         assert result.stdout == "3\n"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -109,6 +109,20 @@ def test_list_with_python(cli: click.testing.CliRunner) -> None:
             )
 
 
+def test_list_with_interpreters_only(cli: click.testing.CliRunner) -> None:
+    """Running list with --interpreters-only should print only unique Python interpreter versions for matching venvs."""
+    with with_riotfile(cli, "empty_riotfile.py"):
+        result = cli.invoke(riot.cli.main, ["list", "--interpreters-only"])
+        # Success, but no output because no venvs to list
+        assert result.exit_code == 0
+        assert result.stdout == ""
+
+    with with_riotfile(cli, "simple_riotfile.py"):
+        result = cli.invoke(riot.cli.main, ["list", "--interpreters-only"])
+        # Success, should list 2 venvs with py=3
+        assert result.exit_code == 0, result.stdout
+        assert result.stdout == "3\n"
+
 def test_run_with_long_args(cli: click.testing.CliRunner) -> None:
     """Running run with long option names uses those options."""
     with mock.patch("riot.cli.Session.run") as run:


### PR DESCRIPTION
This change adds a `-i, --interpreters` flag to the `riot list` command. If set to true, this flag should cause the `riot list` command to output a list of unique python interpreters for each matching venv instead of the overall table that the default command generates.

Example:
```shell
(.venv) riot % riot list test
No.  Hash     Name  Interpreter                Environment  Packages                                                        
 #0   51feb80  test  Interpreter(_hint='3.6')   --           'pytest' 'pytest-cov' 'pytest-xdist' 'mock' 'typing-extensions' 
 #1   8498bd5  test  Interpreter(_hint='3.7')   --           'pytest' 'pytest-cov' 'pytest-xdist' 'mock' 'typing-extensions' 
 #2   1afefb9  test  Interpreter(_hint='3.8')   --           'pytest' 'pytest-cov' 'pytest-xdist' 'mock' 'typing-extensions' 
 #3   e78d3c6  test  Interpreter(_hint='3.9')   --           'pytest' 'pytest-cov' 'pytest-xdist' 'mock' 'typing-extensions' 
 #4   dbf03ce  test  Interpreter(_hint='3.10')  --           'pytest' 'pytest-cov' 'pytest-xdist' 'mock' 'typing-extensions'
(.venv)  riot % riot list --interpreters test
3.6,3.7,3.8,3.9,3.10
```