### PR TITLE
feat(venv): add pip install options

### DIFF
--- a/releasenotes/notes/add-pip-install-options-1d99d61f24e8ee15.yaml
+++ b/releasenotes/notes/add-pip-install-options-1d99d61f24e8ee15.yaml
@@ -1,0 +1,4 @@
+---
+features:
+  - |
+    adds `install_options` field to `riot.Venv`. This field can be used to pass options to `pip install` commands.

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -871,3 +871,22 @@ setup(
         r"Setting venv path to .+[.]riot/venv_py[0-9]+_requests", result.stderr
     )
     assert result.returncode == 0, result.stderr
+
+
+def test_install_options(tmp_path: pathlib.Path, tmp_run: _T_TmpRun) -> None:
+    rf_path = tmp_path / "riotfile.py"
+    rf_path.write_text(
+        """
+from riot import Venv, latest
+venv = Venv(
+    name="test_install_options",
+    install_options="--dry-run",
+    pys=["3"],
+    pkgs={"gevent": latest},
+    command="echo dry run complete",
+)
+""",
+    )
+    result = tmp_run("riot -v run -s test_install_options")
+    assert "dry run complete" in result.stdout
+    assert result.returncode == 0, result.stderr


### PR DESCRIPTION
Adds support for passing [pip install options](https://pip.pypa.io/en/stable/cli/pip_install/#pip-install) to riot venvs. 

