### PR TITLE
feat: add riot list --hash-only option to list only venv short hashes

### DIFF
--- a/releasenotes/notes/add-list-hash-only-ee2b1414b6b41f72.yaml
+++ b/releasenotes/notes/add-list-hash-only-ee2b1414b6b41f72.yaml
@@ -1,0 +1,4 @@
+---
+features:
+  - |
+    add ``riot list --hash-only`` option to list only venv short hashes

--- a/riot/cli.py
+++ b/riot/cli.py
@@ -99,14 +99,22 @@ def main(ctx, riotfile, log_level, pipe_mode):
 @PATTERN_ARG
 @VENV_PATTERN_ARG
 @INTERPRETERS_ARG
+@click.option(
+    "--hash-only",
+    "hash_only",
+    is_flag=True,
+    default=False,
+    help="Only print the hashes of matched venvs",
+)
 @click.pass_context
-def list_venvs(ctx, pythons, pattern, venv_pattern, interpreters):
+def list_venvs(ctx, pythons, pattern, venv_pattern, interpreters, hash_only):
     ctx.obj["session"].list_venvs(
         re.compile(pattern),
         re.compile(venv_pattern),
         pythons=pythons,
         pipe_mode=ctx.obj["pipe"],
         interpreters=interpreters,
+        hash_only=hash_only,
     )
 
 

--- a/riot/riot.py
+++ b/riot/riot.py
@@ -814,10 +814,12 @@ class Session:
         out=sys.stdout,
         pipe_mode=False,
         interpreters=False,
+        hash_only=False,
     ):
         python_interpreters = set()
+        venv_hashes = set()
         table = None
-        if not (pipe_mode or interpreters):
+        if not (pipe_mode or interpreters or hash_only):
             table = Table(
                 "No.",
                 "Hash",
@@ -839,9 +841,11 @@ class Session:
                 continue
             pkgs_str = inst.full_pkg_str
             env_str = env_to_str(inst.env)
-            if interpreters:
+            if interpreters or hash_only:
                 python_interpreters.add(inst.py._hint)
+                venv_hashes.add(inst.short_hash)
                 continue
+
             if pipe_mode:
                 print(
                     f"[#{n}]  {inst.short_hash}  {inst.name:12} {env_str} {inst.py} Packages({pkgs_str})"
@@ -859,7 +863,10 @@ class Session:
         if table:
             rich_print(table)
 
-        if interpreters and python_interpreters:
+        elif hash_only and venv_hashes:
+            print("\n".join(sorted(venv_hashes)))
+
+        elif interpreters and python_interpreters:
             print("\n".join(sorted(python_interpreters, key=Version)))
 
     def generate_base_venvs(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -128,6 +128,28 @@ def test_list_with_interpreters_only(cli: click.testing.CliRunner) -> None:
         assert result.stdout == "2.7\n3.5\n3.6\n3.7\n3.8\n3.9\n"
 
 
+def test_list_with_hash_only(cli: click.testing.CliRunner) -> None:
+    """Running list with --hash-only should print unique test venv short hashes only."""
+    with with_riotfile(cli, "empty_riotfile.py"):
+        result = cli.invoke(riot.cli.main, ["list", "--hash-only"])
+        # Success, but no output because no venvs to list
+        assert result.exit_code == 0
+        assert result.stdout == ""
+
+    with with_riotfile(cli, "simple_riotfile.py"):
+        result = cli.invoke(riot.cli.main, ["list", "--hash-only"])
+        assert result.exit_code == 0, result.stdout
+        assert result.stdout == "2dd7a54\n4375064\n"
+
+    with with_riotfile(cli, "diff_pys_riotfile.py"):
+        result = cli.invoke(riot.cli.main, ["list", "--hash-only"])
+        assert result.exit_code == 0, result.stdout
+        assert (
+            result.stdout
+            == "10caf25\n1148750\n1a47d0a\n1e9988e\n453e5ba\n5a99917\n6039693\n6bc39d3\n6e52e25\n77d5b15\n8d17393\nf65004c\n"
+        )
+
+
 def test_run_with_long_args(cli: click.testing.CliRunner) -> None:
     """Running run with long option names uses those options."""
     with mock.patch("riot.cli.Session.run") as run:


### PR DESCRIPTION
riot supports doing `riot run <short-hash>`, by offering a way to do `riot list`
and only print the short hashes, we can then support better paralellization in CI.

e.g. `riot list --hash-only | circleci tests split | xargs -n 1 riot -v run`

This would allow us to scale the number of parallel nodes however we want.