### PR TITLE
feat: add requirements caching

### DIFF
--- a/releasenotes/notes/locks-66113372ce122a52.yaml
+++ b/releasenotes/notes/locks-66113372ce122a52.yaml
@@ -1,0 +1,6 @@
+---
+features:
+  - Adds the ``riot requirements <hash>`` command, which uses pip-compile to generate a requirements lockfile for venv identified by the hash
+  - |
+    Adds the ``-c/--recompile-requirements`` flag to ``riot run``. When set, this flag causes the requirements.txt lockfile and the venv itself
+    to be regenerated. When omitted, the requirements lockfile is only built if it does not already exist.

--- a/riot/cli.py
+++ b/riot/cli.py
@@ -50,6 +50,13 @@ INTERPRETERS_ARG = click.option(
     is_flag=True,
     default=False,
 )
+RECOMPILE_REQS_ARG = click.option(
+    "-c",
+    "--recompile-requirements",
+    "recompile_reqs",
+    is_flag=True,
+    default=False,
+)
 
 
 @click.group()
@@ -156,6 +163,7 @@ def generate(ctx, recreate_venvs, skip_base_install, pythons, pattern):
 @click.option("--exitfirst", "-x", "exit_first", is_flag=True, default=False)
 @PATTERN_ARG
 @VENV_PATTERN_ARG
+@RECOMPILE_REQS_ARG
 @click.pass_context
 def run(
     ctx,
@@ -167,6 +175,7 @@ def run(
     exit_first,
     pattern,
     venv_pattern,
+    recompile_reqs,
 ):
     ctx.obj["session"].run(
         pattern=re.compile(pattern),
@@ -178,6 +187,7 @@ def run(
         pythons=pythons,
         skip_missing=skip_missing,
         exit_first=exit_first,
+        recompile_reqs=recompile_reqs,
     )
 
 
@@ -189,4 +199,13 @@ def shell(ctx, ident, pass_env):
     ctx.obj["session"].shell(
         ident=ident,
         pass_env=pass_env,
+    )
+
+
+@main.command("requirements", help="""Cache requirements for a venv.""")
+@click.argument("ident", type=str)
+@click.pass_context
+def requirements(ctx, ident):
+    ctx.obj["session"].requirements(
+        ident=ident,
     )

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -52,6 +52,7 @@ def assert_args(args):
             "pythons",
             "skip_missing",
             "exit_first",
+            "recompile_reqs",
         ]
     )
 

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -329,7 +329,7 @@ def test_session_run_check_environment_modifications_and_recreate_true(
 ) -> None:
     """Validate session run method.
 
-    Create nested environments, edit the packages installed with pip isntall
+    Create nested environments, edit the packages installed with pip install
     and validate the nested packages are restored after execute again session.run
     with recreate_venvs equal to True.
     """


### PR DESCRIPTION
 This change adds the `riot requirements <hash>` command, which uses pip-compile to generate a requirements lockfile for the venv identified by the hash. It also adds the `-c/--recompile-requirements` flag to `riot run`. When set, this flag causes the requirements.txt lockfile and the venv itself to be regenerated. When omitted, the requirements lockfile is only built if it does not already exist.

This is a useful feature because it reduces duplicated work during `riot run`. In current master, every `riot run` has to build the dependency tree for its venv before installing those dependencies. With this change, the built dependency tree is saved in the form of a lockfile and reused on subsequent `riot run` invocations.