### PR TITLE
chore: don't install requirements in intermediate venvs

### DIFF
--- a/riot/riot.py
+++ b/riot/riot.py
@@ -420,8 +420,8 @@ class VenvInstance:
             return None
         return "_".join(
             (
-                f"{rmchars('<=>.,:+@/', n)}{rmchars('<=>.,:+@/', v)}"
-                for n, v in self.pkgs.items()
+                f"{rmchars('<=>.,:+@/', n)}"
+                for n in self.full_pkg_str.replace("'", "").split()
             )
         )
 

--- a/riot/riot.py
+++ b/riot/riot.py
@@ -585,7 +585,7 @@ class VenvInstance:
         installed = False
         # We only install dependencies if the prefix directory does not
         # exist already. If it does exist, we assume it is in a good state.
-        already_exists = self.prefix is None or os.path.isdir(self.prefix)
+        already_exists = self.prefix is not None and os.path.isdir(self.prefix)
         if (
             py is not None
             and self.pkgs

--- a/riot/riot.py
+++ b/riot/riot.py
@@ -585,11 +585,12 @@ class VenvInstance:
         installed = False
         # We only install dependencies if the prefix directory does not
         # exist already. If it does exist, we assume it is in a good state.
+        already_exists = os.path.isdir(self.prefix)
         if (
             py is not None
             and self.pkgs
             and self.prefix is not None
-            and (not os.path.isdir(self.prefix) or recreate or recompile_reqs)
+            and (not already_exists or recreate or recompile_reqs)
             and (has_own_py or not traversing)
         ):
             venv_path = self.venv_path
@@ -631,7 +632,7 @@ class VenvInstance:
                 installed = True
 
         if not self.created and self.parent is not None:
-            self.parent.prepare(env, py, traversing=installed)
+            self.parent.prepare(env, py, traversing=installed or already_exists)
 
 
 @dataclasses.dataclass

--- a/riot/riot.py
+++ b/riot/riot.py
@@ -1,5 +1,7 @@
+from contextlib import contextmanager
 import dataclasses
 import functools
+from hashlib import sha256
 import importlib.abc
 import importlib.util
 import itertools
@@ -11,12 +13,10 @@ import sys
 import tempfile
 import traceback
 import typing as t
-from contextlib import contextmanager
-from hashlib import sha256
 
 import click
-import pexpect
 from packaging.version import Version
+import pexpect
 from rich import print as rich_print
 from rich.pretty import Pretty
 from rich.status import Status

--- a/riot/riot.py
+++ b/riot/riot.py
@@ -581,6 +581,8 @@ class VenvInstance:
         if recompile_reqs:
             recreate = True
 
+        exists = self.prefix is not None and os.path.isdir(self.prefix)
+
         installed = False
         if (
             py is not None
@@ -631,7 +633,7 @@ class VenvInstance:
 
         if not self.created and self.parent is not None:
             self.parent.prepare(
-                env, py, child_was_installed=installed or child_was_installed
+                env, py, child_was_installed=installed or exists or child_was_installed
             )
 
 

--- a/riot/riot.py
+++ b/riot/riot.py
@@ -582,6 +582,7 @@ class VenvInstance:
         if recompile_reqs:
             recreate = True
 
+        installed = False
         # We only install dependencies if the prefix directory does not
         # exist already. If it does exist, we assume it is in a good state.
         if (
@@ -626,9 +627,11 @@ class VenvInstance:
                     f"Failed to install venv dependencies {pkg_str}\n{e.proc.stdout}",
                     e.proc,
                 )
+            else:
+                installed = True
 
         if not self.created and self.parent is not None:
-            self.parent.prepare(env, py, traversing=True)
+            self.parent.prepare(env, py, traversing=installed)
 
 
 @dataclasses.dataclass

--- a/riot/riot.py
+++ b/riot/riot.py
@@ -1,7 +1,5 @@
-from contextlib import contextmanager
 import dataclasses
 import functools
-from hashlib import sha256
 import importlib.abc
 import importlib.util
 import itertools
@@ -13,10 +11,12 @@ import sys
 import tempfile
 import traceback
 import typing as t
+from contextlib import contextmanager
+from hashlib import sha256
 
 import click
-from packaging.version import Version
 import pexpect
+from packaging.version import Version
 from rich import print as rich_print
 from rich.pretty import Pretty
 from rich.status import Status
@@ -585,7 +585,7 @@ class VenvInstance:
         installed = False
         # We only install dependencies if the prefix directory does not
         # exist already. If it does exist, we assume it is in a good state.
-        already_exists = os.path.isdir(self.prefix)
+        already_exists = self.prefix is None or os.path.isdir(self.prefix)
         if (
             py is not None
             and self.pkgs

--- a/riot/riot.py
+++ b/riot/riot.py
@@ -574,7 +574,9 @@ class VenvInstance:
         recreate: bool = False,
         skip_deps: bool = False,
         recompile_reqs: bool = False,
+        traversing: bool = False,
     ) -> None:
+        has_own_py = self.py is not None
         # Propagate the interpreter down the parenting relation
         self.py = py = py or self.py
         if recompile_reqs:
@@ -587,6 +589,7 @@ class VenvInstance:
             and self.pkgs
             and self.prefix is not None
             and (not os.path.isdir(self.prefix) or recreate or recompile_reqs)
+            and (has_own_py or not traversing)
         ):
             venv_path = self.venv_path
             assert venv_path is not None, py
@@ -625,7 +628,7 @@ class VenvInstance:
                 )
 
         if not self.created and self.parent is not None:
-            self.parent.prepare(env, py)
+            self.parent.prepare(env, py, traversing=True)
 
 
 @dataclasses.dataclass

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -548,8 +548,7 @@ def test_success():
     assert os.environ["RIOT"] == "1"
     assert os.environ["RIOT_PYTHON_HINT"] == "Interpreter(_hint='3')"
     assert os.environ["RIOT_PYTHON_VERSION"].startswith("3.")
-    assert os.environ["RIOT_VENV_HASH"] == "f8691e0"
-    assert os.environ["RIOT_VENV_IDENT"] == "packaging213"
+    assert os.environ["RIOT_VENV_IDENT"] == "pytest_packaging213"
     assert os.environ["RIOT_VENV_NAME"] == "envtest"
     assert os.environ["RIOT_VENV_PKGS"] == "'packaging>=21.3'"
     assert os.environ["RIOT_VENV_FULL_PKGS"] == "'pytest' 'packaging>=21.3'"

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -649,7 +649,7 @@ venv = Venv(
 
     version = "".join((str(_) for _ in sys.version_info[:3]))
 
-    venv_name = f"venv_py{version}_pytest"
+    venv_name = f"venv_py{version}_pip_pytest"
     parent_venv_name = f"venv_py{version}_pip"
     py_dot_version = ".".join((str(_) for _ in sys.version_info[:2]))
 
@@ -708,7 +708,7 @@ venv = Venv(
     env = dict(_.split("=", maxsplit=1) for _ in result.stdout.splitlines() if "=" in _)
     assert result.returncode == 0, result.stderr
 
-    venv_name = "venv_py{}_pytest".format(
+    venv_name = "venv_py{}_pip_pytest".format(
         "".join((str(_) for _ in sys.version_info[:3]))
     )
     parent_venv_name = "venv_py{}_pip".format(
@@ -783,7 +783,7 @@ venv = Venv(
 """,
     )
     result = tmp_run("riot -Pv run -s child")
-    venv_path = tmp_path / ".riot/venv_py{}_pytest_pip".format(
+    venv_path = tmp_path / ".riot/venv_py{}_pip_pytest".format(
         "".join((str(_) for _ in sys.version_info[:3]))
     )
     assert f"Creating virtualenv '{venv_path}'" in result.stderr, result.stderr

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -272,7 +272,7 @@ def test_session_run(session_virtualenv: Session) -> None:
     """
     session_virtualenv.run(re.compile(""), re.compile(""), False, False)
 
-    env_name = "venv_py%s%s%s_six1150_isort5101_itsdangerous110" % sys.version_info[:3]
+    env_name = "venv_py%s%s%s_itsdangerous110_isort5101_six1150" % sys.version_info[:3]
     command_env = _get_env(env_name)
     # Check exists and is empty of packages
     result = _get_pip_freeze(command_env)
@@ -291,7 +291,7 @@ def test_session_run_check_environment_modifications(
     """
     session_virtualenv.run(re.compile(""), re.compile(""), False, False)
 
-    env_name = "venv_py%s%s%s_six1150_isort5101_itsdangerous110" % sys.version_info[:3]
+    env_name = "venv_py%s%s%s_itsdangerous110_isort5101_six1150" % sys.version_info[:3]
     command_env = _get_env(env_name)
     _run_pip_install("itsdangerous==0.24", command_env)
     # Check exists and is empty of packages
@@ -312,7 +312,7 @@ def test_session_run_check_environment_modifications_and_recreate_false(
     """
     session_virtualenv.run(re.compile(""), re.compile(""), False, False)
 
-    env_name = "venv_py%s%s%s_six1150_isort5101_itsdangerous110" % sys.version_info[:3]
+    env_name = "venv_py%s%s%s_itsdangerous110_isort5101_six1150" % sys.version_info[:3]
     command_env = _get_env(env_name)
     _run_pip_install("itsdangerous==0.24", command_env)
 
@@ -335,7 +335,7 @@ def test_session_run_check_environment_modifications_and_recreate_true(
     """
     session_virtualenv.run(re.compile(""), re.compile(""), False, False)
 
-    env_name = "venv_py%s%s%s_six1150_isort5101_itsdangerous110" % sys.version_info[:3]
+    env_name = "venv_py%s%s%s_itsdangerous110_isort5101_six1150" % sys.version_info[:3]
     command_env = _get_env(env_name)
     _run_pip_install("itsdangerous==0.24", command_env)
 


### PR DESCRIPTION
This change removes some duplicated work involved in building nested virtualenvs. Because the pip install at the leaf node of a Venv tree installs all of the requirements of that tree, it's redundant to install some requirements again as execution traverses the parent relations. This change causes those parent-Venv installations to be skipped.