### PR TITLE
fix: change how Venvs are hashed

### DIFF
--- a/releasenotes/notes/stable-hash-63389fa04cca60ab.yaml
+++ b/releasenotes/notes/stable-hash-63389fa04cca60ab.yaml
@@ -2,4 +2,4 @@
 fixes:
   - |
     Fixes a bug causing virtualenv hashes to change during command execution, leading to installed
-    dependencies not being found
+    dependencies not being found.

--- a/releasenotes/notes/stable-hash-63389fa04cca60ab.yaml
+++ b/releasenotes/notes/stable-hash-63389fa04cca60ab.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    Fixes a bug causing virtualenv hashes to change during command execution, leading to installed
+    dependencies not being found

--- a/releasenotes/notes/stable-hash-63389fa04cca60ab.yaml
+++ b/releasenotes/notes/stable-hash-63389fa04cca60ab.yaml
@@ -1,5 +1,0 @@
----
-fixes:
-  - |
-    Fixes a bug causing virtualenv hashes to change during command execution, leading to installed
-    dependencies not being found.

--- a/riot/riot.py
+++ b/riot/riot.py
@@ -456,6 +456,7 @@ class VenvInstance:
     def __hash__(self):
         """Compute a hash for the venv instance."""
         h = sha256()
+        h.update(repr(self.name).encode())
         h.update(repr(self.py).encode())
         h.update(self.full_pkg_str.encode())
         return int(h.hexdigest(), 16)

--- a/riot/riot.py
+++ b/riot/riot.py
@@ -447,7 +447,7 @@ class VenvInstance:
 
     @property
     def long_hash(self) -> str:
-        return hex(hash(self))[2:]
+        return hex(hash(self.full_pkg_str))[2:]
 
     @property
     def short_hash(self) -> str:

--- a/riot/riot.py
+++ b/riot/riot.py
@@ -447,7 +447,7 @@ class VenvInstance:
 
     @property
     def long_hash(self) -> str:
-        return hex(hash(self.full_pkg_str))[2:]
+        return hex(hash(self))[2:]
 
     @property
     def short_hash(self) -> str:
@@ -456,7 +456,6 @@ class VenvInstance:
     def __hash__(self):
         """Compute a hash for the venv instance."""
         h = sha256()
-        h.update(repr(self).encode())
         h.update(self.full_pkg_str.encode())
         return int(h.hexdigest(), 16)
 

--- a/riot/riot.py
+++ b/riot/riot.py
@@ -456,6 +456,7 @@ class VenvInstance:
     def __hash__(self):
         """Compute a hash for the venv instance."""
         h = sha256()
+        h.update(repr(self.py).encode())
         h.update(self.full_pkg_str.encode())
         return int(h.hexdigest(), 16)
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -75,7 +75,7 @@ def test_list_with_venv_pattern(cli: click.testing.CliRunner) -> None:
         assert result.exit_code == 0, result.stdout
         assert (
             result.stdout
-            == "[#0]  4375064  test          Interpreter(_hint='3') Packages('pytest==5.4.3')\n"
+            == "[#0]  1dacd4b  test          Interpreter(_hint='3') Packages('pytest==5.4.3')\n"
         )
 
 
@@ -140,14 +140,14 @@ def test_list_with_hash_only(cli: click.testing.CliRunner) -> None:
     with with_riotfile(cli, "simple_riotfile.py"):
         result = cli.invoke(riot.cli.main, ["list", "--hash-only"])
         assert result.exit_code == 0, result.stdout
-        assert result.stdout == "2dd7a54\n4375064\n"
+        assert result.stdout == "1299ca6\n1dacd4b\n"
 
     with with_riotfile(cli, "diff_pys_riotfile.py"):
         result = cli.invoke(riot.cli.main, ["list", "--hash-only"])
         assert result.exit_code == 0, result.stdout
         assert (
             result.stdout
-            == "10caf25\n1148750\n1a47d0a\n1e9988e\n453e5ba\n5a99917\n6039693\n6bc39d3\n6e52e25\n77d5b15\n8d17393\nf65004c\n"
+            == "190e001\n1a01036\n1bbc7ba\n1fedf51\n2c180ee\n693842d\n699434a\n6f0bed0\na31c49f\na385c7e\nc928c36\nf23c6ff\n"
         )
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -75,7 +75,7 @@ def test_list_with_venv_pattern(cli: click.testing.CliRunner) -> None:
         assert result.exit_code == 0, result.stdout
         assert (
             result.stdout
-            == "[#0]  1dacd4b  test          Interpreter(_hint='3') Packages('pytest==5.4.3')\n"
+            == "[#0]  1be43f6  test          Interpreter(_hint='3') Packages('pytest==5.4.3')\n"
         )
 
 
@@ -140,14 +140,14 @@ def test_list_with_hash_only(cli: click.testing.CliRunner) -> None:
     with with_riotfile(cli, "simple_riotfile.py"):
         result = cli.invoke(riot.cli.main, ["list", "--hash-only"])
         assert result.exit_code == 0, result.stdout
-        assert result.stdout == "1299ca6\n1dacd4b\n"
+        assert result.stdout == "1be43f6\n3f0bd68\n"
 
     with with_riotfile(cli, "diff_pys_riotfile.py"):
         result = cli.invoke(riot.cli.main, ["list", "--hash-only"])
         assert result.exit_code == 0, result.stdout
         assert (
             result.stdout
-            == "190e001\n1a01036\n1bbc7ba\n1fedf51\n2c180ee\n693842d\n699434a\n6f0bed0\na31c49f\na385c7e\nc928c36\nf23c6ff\n"
+            == "156e0a3\n175f9ae\n1a1f742\n1f0f227\n524376c\n60d413e\n61b42ab\n83b22e0\n89d1e7a\n982a4b5\nb1c318a\nbdc1729\n"
         )
 
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -227,7 +227,7 @@ venv = Venv(
     assert result.stderr == ""
     assert (
         result.stdout
-        == "[#0]  1c31170  test          Interpreter(_hint='3') Packages()\n"
+        == "[#0]  1f92574  test          Interpreter(_hint='3') Packages()\n"
     )
     assert result.returncode == 0
 
@@ -410,11 +410,11 @@ venv = Venv(
     assert result.returncode == 0
 
     # Listing by hash works
-    result = tmp_run("riot -P list 144c8c4")
+    result = tmp_run("riot -P list 175d38a")
     assert result.stderr == ""
     assert re.search(
         r"""
-\[\#7\]  144c8c4  test2  .* Packages\('pkg1==2.0' 'pkg2==4.0'\)
+\[\#7\]  175d38a  test2  .* Packages\('pkg1==2.0' 'pkg2==4.0'\)
 """.lstrip(),
         result.stdout,
     )

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -227,7 +227,7 @@ venv = Venv(
     assert result.stderr == ""
     assert (
         result.stdout
-        == "[#0]  1f92574  test          Interpreter(_hint='3') Packages()\n"
+        == "[#0]  702abfd  test          Interpreter(_hint='3') Packages()\n"
     )
     assert result.returncode == 0
 
@@ -410,11 +410,11 @@ venv = Venv(
     assert result.returncode == 0
 
     # Listing by hash works
-    result = tmp_run("riot -P list 175d38a")
+    result = tmp_run("riot -P list 61ec44a")
     assert result.stderr == ""
     assert re.search(
         r"""
-\[\#7\]  175d38a  test2  .* Packages\('pkg1==2.0' 'pkg2==4.0'\)
+\[\#3\]  61ec44a  test1  .* Packages\('pkg1==2.0' 'pkg2==4.0'\)
 """.lstrip(),
         result.stdout,
     )

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -184,13 +184,13 @@ def test_venv_matching(current_interpreter: Interpreter) -> None:
         "^test$",
         "^(no_match)|(test)$",
         # Short hash
-        "137331a",
-        ".*733.*",
-        "[0-9]*a",
-        "^137331a",
-        "137331a$",
-        "^137331a$",
-        "^(no_match)|(137331a)$",
+        "1250e4d",
+        ".*250.*",
+        "[0-9e]*d",
+        "^1250e4d",
+        "1250e4d$",
+        "^1250e4d$",
+        "^(no_match)|(1250e4d)$",
     ],
 )
 def test_venv_name_matching(pattern: str) -> None:
@@ -201,7 +201,7 @@ def test_venv_name_matching(pattern: str) -> None:
         pkgs={"pip": ""},
         py=Interpreter("3"),
     )
-    assert venv.short_hash == "137331a"
+    assert venv.short_hash == "1250e4d"
     assert venv.matches_pattern(re.compile(pattern))
 
 

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -184,13 +184,13 @@ def test_venv_matching(current_interpreter: Interpreter) -> None:
         "^test$",
         "^(no_match)|(test)$",
         # Short hash
-        "1250e4d",
-        ".*250.*",
-        "[0-9e]*d",
-        "^1250e4d",
-        "1250e4d$",
-        "^1250e4d$",
-        "^(no_match)|(1250e4d)$",
+        "1d63e3e",
+        ".*d63.*",
+        "[0-9de]*",
+        "^1d63e3e",
+        "1d63e3e$",
+        "^1d63e3e$",
+        "^(no_match)|(1d63e3e)$",
     ],
 )
 def test_venv_name_matching(pattern: str) -> None:
@@ -201,7 +201,7 @@ def test_venv_name_matching(pattern: str) -> None:
         pkgs={"pip": ""},
         py=Interpreter("3"),
     )
-    assert venv.short_hash == "1250e4d"
+    assert venv.short_hash == "1d63e3e"
     assert venv.matches_pattern(re.compile(pattern))
 
 


### PR DESCRIPTION
This change removes `self` from the seed used to generate Venv hashes. This is because recent changes to the requirements installation logic mutated `self` between installation and pythonpath generation in such a way as to change the resulting hash. This meant that the virtualenv pointed to in the pythonpath was not the same one that had been generated for the current command run.

Basing the hash solely on attributes that don't change during execution keeps it stable per run.

This has been tested on dd-trace-py https://github.com/DataDog/dd-trace-py/pull/5227/commits/492fc0d8b21e537541befce36ac77478c6ed4f29