### PR TITLE
fix: pin virtualenv version to 20.20.0

### DIFF
--- a/releasenotes/notes/fix-python-2-7-pinning-virtualenv-619b531a9ea8c695.yaml
+++ b/releasenotes/notes/fix-python-2-7-pinning-virtualenv-619b531a9ea8c695.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Avoid using latests versions of ``virtualenv`` since it has dropped support for Python 2.7.

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ setup(
     install_requires=[
         "dataclasses; python_version<'3.7'",
         "click>=7",
-        "virtualenv==20.20.0",
+        "virtualenv<=20.20.0",
         "rich",
         "pexpect",
         "packaging",

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ setup(
     install_requires=[
         "dataclasses; python_version<'3.7'",
         "click>=7",
-        "virtualenv",
+        "virtualenv==20.20.0",
         "rich",
         "pexpect",
         "packaging",


### PR DESCRIPTION
Virtualenv dropped support for Python 2.7, so we need to pin this requirement in order to keep creating 2.7 virtualenvs