### PR TITLE
chore(ci): replace ubuntu-18.04 runner with ubuntu-latest

### DIFF
--- a/.github/workflows/build_deploy.yml
+++ b/.github/workflows/build_deploy.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   build_wheel:
     name: Build wheels
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
`ubuntu-18.04` is deprecated.