### PR TITLE
feat: ensure hash consistency between lockfile and venv

### DIFF
--- a/releasenotes/notes/emptypkgs-21c00f01a644170d.yaml
+++ b/releasenotes/notes/emptypkgs-21c00f01a644170d.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    Fixes an issue in which riot generated a requirements lockfile for a Venv instance other than the one it was running tests for.
+    This behavior was happening due to logic that skipped Venv instances with pkgs == None while preparing the environment,
+    but not while running tests. The fix is to stop riot from ignoring pkgs-less Venvs in all cases.

--- a/riot/riot.py
+++ b/riot/riot.py
@@ -383,7 +383,7 @@ class VenvInstance:
         This will return a python version + package specific path name.
         If no packages are defined it will return ``None``.
         """
-        if self.py is None or not self.pkgs:
+        if self.py is None:
             return None
 
         venv_path = self.py.venv_path
@@ -416,8 +416,6 @@ class VenvInstance:
     @property
     def ident(self) -> t.Optional[str]:
         """Return prefix identifier string based on packages."""
-        if not self.pkgs:
-            return None
         return "_".join(
             (
                 f"{rmchars('<=>.,:+@/', n)}"
@@ -587,7 +585,6 @@ class VenvInstance:
         installed = False
         if (
             py is not None
-            and self.pkgs
             and self.prefix is not None
             # We only install dependencies if the prefix directory does not
             # exist already. If it does exist, we assume it is in a good state.


### PR DESCRIPTION
This change fixes an issue observable in [this test run](https://app.circleci.com/pipelines/github/DataDog/dd-trace-py/34529/workflows/3cde9cd7-6ea9-4ebc-95a5-a54bf6e9c648/jobs/2334921) in which riot generated a requirements lockfile for a `Venv` instance other than the one it was running tests for. This behavior was happening due to riot logic that skipped `Venv` instances with `pkgs == None` while preparing the environment, but not while running tests. Thus the fix is to stop riot from ignoring `pkgs`-less `Venv`s in all cases.

Note these two lines of output from the example test run:
```
Compiling requirements file .riot/requirements/118238b.in
RIOT_VENV_HASH=32bd6c2
```
This illustrates the mismatch. `RIOT_VENV_HASH` is the hash of the environment in which the command will be run, and for which the lockfile should be generated. The `prepare()` function had been ignoring that environment and instead preparing an environment for one of its ancestors.