### PR TITLE
fix: install dev package in its own prefix

### DIFF
--- a/releasenotes/notes/fix-dev-pkg-prefix-cdce8c029dfe3dff.yaml
+++ b/releasenotes/notes/fix-dev-pkg-prefix-cdce8c029dfe3dff.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    Fixed a problem that caused dependency layers to uninstall some dev package
+    dependencies from the base virtual environment.

--- a/riot/_hotfix/sitecustomize.py
+++ b/riot/_hotfix/sitecustomize.py
@@ -1,0 +1,22 @@
+import os
+
+from pip._internal.build_env import BuildEnvironment as BE
+
+original_be_enter = BE.__enter__
+
+
+def be_enter(self):
+    pythonpath = os.getenv("PYTHONPATH")
+    try:
+        return original_be_enter(self)
+    finally:
+        # We fix the PYTHONPATH override done by pip before returning
+        if pythonpath is not None:
+            os.environ["PYTHONPATH"] = os.pathsep.join(
+                (os.getenv("PYTHONPATH"), pythonpath)
+            )
+
+
+# pip does not support edit install with prefix in Python 2
+# https://github.com/pypa/pip/issues/7627
+BE.__enter__ = be_enter


### PR DESCRIPTION
Resolves: https://github.com/DataDog/riot/issues/211

This prevents any dependency layers from removing the dev package dependencies from the base environment.