### PR TITLE
fix: use dedicated venv for installing dependencies

### DIFF
--- a/releasenotes/notes/fix-preserve-base-venv-d3f406358e593c30.yaml
+++ b/releasenotes/notes/fix-preserve-base-venv-d3f406358e593c30.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    Fixed an issue that caused base virtual environments to get modified when
+    common dependencies were installed in child virtual environments.

--- a/riot/riot.py
+++ b/riot/riot.py
@@ -7,6 +7,7 @@ import importlib.util
 import itertools
 import logging
 import os
+from pathlib import Path
 import shutil
 import subprocess
 import sys
@@ -134,15 +135,9 @@ class Interpreter:
         return os.path.join(self.venv_path, "bin")
 
     @property
-    def dev_pkg_bin_path(self) -> t.Optional[str]:
-        return os.path.join(self.dev_pkg_venv_path, "bin")
-
-    @property
     def site_packages_path(self) -> str:
         version = ".".join((str(_) for _ in self.version_info()[:2]))
-        return os.path.join(
-            self.dev_pkg_venv_path, "lib", f"python{version}", "site-packages"
-        )
+        return os.path.join(self.venv_path, "lib", f"python{version}", "site-packages")
 
     @functools.lru_cache()
     def path(self) -> str:
@@ -180,10 +175,6 @@ class Interpreter:
             os.path.join(env_base_path, f"{DEFAULT_RIOT_ENV_PREFIX}{version}")
         )
 
-    @property
-    def dev_pkg_venv_path(self) -> str:
-        return "_".join((self.venv_path, "dev_pkg"))
-
     def exists(self) -> bool:
         """Return whether the virtual environment for this interpreter exists."""
         return os.path.isdir(self.venv_path)
@@ -214,9 +205,6 @@ class Interpreter:
         )
 
         return True
-
-    def create_dev_pkg_venv(self) -> bool:
-        return self.create_venv(recreate=True, path=self.dev_pkg_venv_path)
 
 
 @dataclasses.dataclass
@@ -268,6 +256,7 @@ class Venv:
     command: t.Optional[str] = None
     venvs: t.List["Venv"] = dataclasses.field(default_factory=list)
     create: bool = False
+    skip_dev_install: bool = False
 
     def __post_init__(self, pys, pkgs, env):
         """Normalize the data."""
@@ -292,14 +281,11 @@ class Venv:
                 for pkgs in expand_specs(self.pkgs):  # type: ignore[attr-defined]
                     inst = VenvInstance(
                         # Bubble up name and command if not overridden
-                        name=self.name or (parent_inst.name if parent_inst else None),
-                        command=self.command
-                        or (parent_inst.command if parent_inst else None),
+                        venv=self,
                         py=py,
                         env=env,
                         pkgs=dict(pkgs),
                         parent=parent_inst,
-                        created=self.create,
                     )
                     if not self.venvs:
                         yield inst
@@ -360,16 +346,22 @@ def nspkgs(inst: "VenvInstance") -> t.Generator[None, None, None]:
 
 @dataclasses.dataclass
 class VenvInstance:
+    venv: Venv
     pkgs: t.Dict[str, str]
     py: Interpreter
     env: t.Dict[str, str]
-    name: t.Optional[str] = None
-    command: t.Optional[str] = None
     parent: t.Optional["VenvInstance"] = None
-    created: bool = False
 
     def __post_init__(self) -> None:
         """Venv instance post-initialization."""
+        self.name: t.Optional[str] = self.venv.name or (
+            self.parent.name if self.parent is not None else None
+        )
+        self.command: t.Optional[str] = self.venv.command or (
+            self.parent.command if self.parent is not None else None
+        )
+
+        self.created = self.venv.create
         if self.created:
             ancestor = self.parent
             while ancestor:
@@ -423,23 +415,6 @@ class VenvInstance:
         # If no created ancestors, return the base venv path
         if self.py is not None:
             return self.py.venv_path
-
-        return None
-
-    @property
-    def dev_pkg_venv_path(self) -> t.Optional[str]:
-        # Try to take the closest created ancestor
-        current: t.Optional[VenvInstance] = self
-        while current:
-            if current.created:
-                # Return the prefix of the created ancestor because the dev
-                # package is installed there
-                return current.prefix
-            current = current.parent
-
-        # If no created ancestors, return the dev package base venv path
-        if self.py is not None:
-            return self.py.dev_pkg_venv_path
 
         return None
 
@@ -549,23 +524,6 @@ class VenvInstance:
         return ":".join(paths)
 
     @property
-    def dev_pkg_scriptpath(self):
-        paths = []
-
-        current: t.Optional[VenvInstance] = self
-        while current is not None and not current.created:
-            if current.pkgs:
-                assert current.bin_path is not None, current
-                paths.append(current.bin_path)
-            current = current.parent
-
-        if not self.created and self.py:
-            if self.py.bin_path is not None:
-                paths.append(self.py.bin_path)
-
-        return ":".join(paths)
-
-    @property
     def site_packages_path(self) -> t.Optional[str]:
         prefix = self.prefix
         if prefix is None:
@@ -643,7 +601,7 @@ class VenvInstance:
 
             if self.created:
                 py.create_venv(recreate, venv_path)
-                if not skip_deps:
+                if not self.venv.skip_dev_install:
                     install_dev_pkg(venv_path)
 
             pkg_str = self.pkg_str
@@ -663,11 +621,19 @@ class VenvInstance:
                 self.prefix,
             )
             try:
-                Session.run_cmd_venv(
-                    venv_path,
-                    cmd,
-                    env=env,
-                )
+                if self.created:
+                    deps_venv_path = venv_path
+                else:
+                    deps_venv_path = venv_path + "_deps"
+                    if py.create_venv(
+                        recreate=False, path=deps_venv_path
+                    ) and py.version_info() < (3,):
+                        # Use the same binary. This is necessary for Python 2.7
+                        deps_bin = (Path(deps_venv_path) / "bin" / "python").resolve()
+                        venv_bin = (Path(venv_path) / "bin" / "python").resolve()
+                        deps_bin.unlink()
+                        deps_bin.symlink_to(venv_bin)
+                Session.run_cmd_venv(deps_venv_path, cmd, env=env)
             except CmdFailure as e:
                 raise CmdFailure(
                     f"Failed to install venv dependencies {pkg_str}\n{e.proc.stdout}",
@@ -790,7 +756,7 @@ class Session:
                 continue
 
             try:
-                venv_path = inst.dev_pkg_venv_path
+                venv_path = inst.venv_path
                 assert venv_path is not None, inst
             except FileNotFoundError:
                 if skip_missing:
@@ -833,8 +799,8 @@ class Session:
 
             inst.prepare(
                 env,
+                skip_deps=skip_base_install or inst.venv.skip_dev_install,
                 recreate=recreate_venvs,
-                skip_deps=skip_base_install,
                 recompile_reqs=recompile_reqs,
             )
 
@@ -845,7 +811,7 @@ class Session:
                     if "PYTHONPATH" in env
                     else pythonpath
                 )
-            script_path = inst.dev_pkg_scriptpath
+            script_path = inst.scriptpath
             if script_path:
                 env["PATH"] = ":".join(
                     (script_path, env.get("PATH", os.environ["PATH"]))
@@ -1029,9 +995,8 @@ class Session:
                     logger.info("Skipping global deps install.")
                     continue
 
-                # Install the dev package into its own base venv.
-                py.create_dev_pkg_venv()
-                install_dev_pkg(py.dev_pkg_venv_path)
+                # Install the dev package into the base venv.
+                install_dev_pkg(py.venv_path)
 
     def _generate_shell_rcfile(self):
         with tempfile.NamedTemporaryFile() as rcfile:
@@ -1089,7 +1054,7 @@ class Session:
                 with tempfile.NamedTemporaryFile() as rcfile:
                     rcfile.write(
                         SHELL_RCFILE.format(
-                            venv_path=inst.dev_pkg_venv_path, name=inst.name
+                            venv_path=venv_path, name=inst.name
                         ).encode()
                     )
                     rcfile.flush()
@@ -1128,6 +1093,21 @@ class Session:
         abs_venv = os.path.abspath(venv)
         env["VIRTUAL_ENV"] = abs_venv
         env["PATH"] = f"{abs_venv}/bin:" + env.get("PATH", "")
+
+        try:
+            # Ensure that we have the venv site-packages in the PYTHONPATH so
+            # that the installed dev package depdendencies are available.
+            sitepkgs_path = (
+                next((Path(abs_venv) / "lib").glob("python*")) / "site-packages"
+            )
+            pythonpath = env.get("PYTHONPATH", None)
+            env["PYTHONPATH"] = (
+                os.pathsep.join((pythonpath, str(sitepkgs_path)))
+                if pythonpath is not None
+                else str(sitepkgs_path)
+            )
+        except StopIteration:
+            pass
 
         for k in cls.ALWAYS_PASS_ENV:
             if k in os.environ and k not in env:

--- a/riotfile.py
+++ b/riotfile.py
@@ -53,6 +53,7 @@ venv = Venv(
                 "pytest": latest,
             },
             create=True,
+            skip_dev_install=True,
         ),
         Venv(
             pys=[3],

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -9,7 +9,6 @@ import pytest
 from riot.riot import _T_CompletedProcess
 from typing_extensions import Protocol
 
-
 _T_Path = Union[str, "os.PathLike[Any]"]
 
 
@@ -612,22 +611,17 @@ venv = Venv(
 
     version = "".join((str(_) for _ in sys.version_info[:3]))
     py_dot_version = ".".join((str(_) for _ in sys.version_info[:2]))
-    assert env["PYTHONPATH"] == ":".join(
-        (
-            "",
-            str(tmp_path),
-            str(
-                tmp_path
-                / os.path.join(
-                    ".riot",
-                    f"venv_py{version}_dev_pkg",
-                    "lib",
-                    f"python{py_dot_version}",
-                    "site-packages",
-                )
-            ),
+    sitepkgs = str(
+        tmp_path
+        / os.path.join(
+            ".riot",
+            f"venv_py{version}",
+            "lib",
+            f"python{py_dot_version}",
+            "site-packages",
         )
     )
+    assert env["PYTHONPATH"] == ":".join(("", str(tmp_path), sitepkgs, sitepkgs))
 
 
 def test_venv_instance_pythonpath(tmp_path: pathlib.Path, tmp_run: _T_TmpRun) -> None:
@@ -658,7 +652,7 @@ venv = Venv(
         tmp_path
         / os.path.join(
             ".riot",
-            f"venv_py{version}_dev_pkg",
+            f"venv_py{version}",
             "lib",
             "python{}".format(py_dot_version),
             "site-packages",
@@ -688,7 +682,14 @@ venv = Venv(
     )
 
     paths = env["PYTHONPATH"].split(":")
-    assert paths == ["", str(tmp_path), venv_path, parent_venv_path, py_venv_path]
+    assert paths == [
+        "",
+        str(tmp_path),
+        venv_path,
+        parent_venv_path,
+        py_venv_path,
+        py_venv_path,
+    ]
 
 
 def test_venv_instance_path(tmp_path: pathlib.Path, tmp_run: _T_TmpRun) -> None:

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -9,6 +9,7 @@ import pytest
 from riot.riot import _T_CompletedProcess
 from typing_extensions import Protocol
 
+
 _T_Path = Union[str, "os.PathLike[Any]"]
 
 
@@ -619,7 +620,7 @@ venv = Venv(
                 tmp_path
                 / os.path.join(
                     ".riot",
-                    f"venv_py{version}",
+                    f"venv_py{version}_dev_pkg",
                     "lib",
                     f"python{py_dot_version}",
                     "site-packages",
@@ -657,7 +658,7 @@ venv = Venv(
         tmp_path
         / os.path.join(
             ".riot",
-            f"venv_py{version}",
+            f"venv_py{version}_dev_pkg",
             "lib",
             "python{}".format(py_dot_version),
             "site-packages",

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -129,9 +129,8 @@ def test_interpreter_venv_path(current_interpreter: Interpreter) -> None:
 
 def test_venv_instance_venv_path(current_interpreter: Interpreter) -> None:
     venv = VenvInstance(
-        command="echo test",
+        venv=Venv(name="test", command="echo test"),
         env={"env": "test"},
-        name="test",
         pkgs={"pip": ""},
         py=current_interpreter,
     )
@@ -153,11 +152,11 @@ def test_interpreter_version_info(current_interpreter: Interpreter) -> None:
 
 def test_venv_matching(current_interpreter: Interpreter) -> None:
     venv = VenvInstance(
-        command="echo test",
+        venv=Venv(command="echo test", name="test"),
         env={"env": "test"},
-        name="test",
         pkgs={"pip": ""},
         parent=VenvInstance(
+            venv=Venv(),
             py=current_interpreter,
             env={},
             pkgs={"pytest": "==5.4.3"},
@@ -195,9 +194,11 @@ def test_venv_matching(current_interpreter: Interpreter) -> None:
 )
 def test_venv_name_matching(pattern: str) -> None:
     venv = VenvInstance(
-        command="echo test",
+        venv=Venv(
+            command="echo test",
+            name="test",
+        ),
         env={"env": "test"},
-        name="test",
         pkgs={"pip": ""},
         py=Interpreter("3"),
     )


### PR DESCRIPTION
We let riot create an auxiliary venv, suffixed with `_deps`, that is used exclusively for installing dependencies in venv layers. This way we can keep the dev package intact in the base venv.