### PR TITLE
fix: pin pip for pip-tools<7

### DIFF
--- a/releasenotes/notes/fix-pin-pip-a9a7467675abb679.yaml
+++ b/releasenotes/notes/fix-pin-pip-a9a7467675abb679.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    pin ``pip<23.2`` to avoid breaking change impacting pip-tools for Python 3.7

--- a/riot/riot.py
+++ b/riot/riot.py
@@ -475,6 +475,12 @@ class VenvInstance:
         subprocess.check_output(
             [self.py.path(), "-m", "pip", "install", "pip-tools"],
         )
+        # pip==23.2 included a breaking change for pip-tools but not available
+        # pip-tools==7.0 fixes this but also dropped support for 3.7
+        if self.py.version_info()[:2] == (3, 7):
+            subprocess.check_output(
+                [self.py.path(), "-m", "pip", "install", "-U", "pip<23.2"],
+            )
         cmd = [
             self.py.path(),
             "-m",


### PR DESCRIPTION
https://github.com/jazzband/pip-tools/pull/1906 is resolved in pip-tools==7.0.0 which happens to also drop support for Python 3.7. This PR pins pip for Python 3.7.

Error:

https://github.com/DataDog/riot/actions/runs/5520208394/job/15245525172

```
ImportError: cannot import name 'DEV_PKGS' from 'pip._internal.commands.freeze' (/opt/hostedtoolcache/Python/3.7.17/x64/lib/python3.7/site-packages/pip/_internal/commands/freeze.py)
```