### PR TITLE
fix: honour the skip option

### DIFF
--- a/releasenotes/notes/fix-honour-skip-option-46042f082772d5d4.yaml
+++ b/releasenotes/notes/fix-honour-skip-option-46042f082772d5d4.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    Fixed a regression that prevented the skip option from being honored when
+    the base venv did not yet exist.

--- a/riot/riot.py
+++ b/riot/riot.py
@@ -997,7 +997,7 @@ class Session:
             except FileNotFoundError:
                 logger.error("Python version '%s' not found.", py)
             else:
-                if not install_deps and skip_deps:
+                if not install_deps or skip_deps:
                     logger.info("Skipping global deps install.")
                     continue
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -476,10 +476,6 @@ test_success.py .*
 1 passed with 0 warnings, 0 failed\n""".lstrip(),
         result.stdout,
     ), result.stdout
-    assert (
-        "No Python setup file found. Skipping dev package installation."
-        in result.stderr
-    )
 
     result = tmp_run("riot run -s fail")
     assert re.search(
@@ -529,10 +525,6 @@ venv = Venv(
     )
     result = tmp_run("riot --pipe run -s test_cmdargs -- -k filter")
     assert "cmdargs=-k filter" not in result.stdout
-    assert (
-        "No Python setup file found. Skipping dev package installation."
-        in result.stderr
-    )
     assert result.returncode == 0
 
     rf_path.write_text(


### PR DESCRIPTION
We fix a regression whereby the skip option was ignored if the base venv did not exist, forcing the installation of the dev package even when requested not to do so.