### PR TITLE
fix: unpin virtualenv for 3.12 support

### DIFF
--- a/releasenotes/notes/fix-312-virtualenv-8bdfefbc33e22465.yaml
+++ b/releasenotes/notes/fix-312-virtualenv-8bdfefbc33e22465.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Install latest ``virtualenv`` to fix support for Python 3.12

--- a/setup.py
+++ b/setup.py
@@ -29,11 +29,12 @@ setup(
     install_requires=[
         "dataclasses; python_version<'3.7'",
         "click>=7",
-        "virtualenv<=20.20.0",
+        "virtualenv<=20.20.0; python<3.12",
         "rich",
         "pexpect",
         "packaging",
         "setuptools; python_version>='3.12'",
+        "virtualenv; python>=3.12",
     ],
     setup_requires=["setuptools_scm"],
     use_scm_version=True,


### PR DESCRIPTION
#205 pinned `virtualenv` but 3.12 support was added since.