### PR TITLE
Move environment variable logging from verbose to debug log level

### DIFF
--- a/releasenotes/notes/move_env_var_logg_to_debug-e5387c563f539c17.yaml
+++ b/releasenotes/notes/move_env_var_logg_to_debug-e5387c563f539c17.yaml
@@ -1,0 +1,4 @@
+---
+other:
+  - |
+    Move environment variable logging to debug log level.

--- a/riot/riot.py
+++ b/riot/riot.py
@@ -824,15 +824,8 @@ class Session:
                         cmdargs=(" ".join(f"'{arg}'" for arg in cmdargs))
                     ).strip()
                 env_str = "\n".join(f"{k}={v}" for k, v in env.items())
-                logger.info(
-                    "Running command '%s' in venv '%s'.",
-                    command,
-                    venv_path
-                )
-                logger.debug(
-                    "Environment variables:\n%s",
-                    env_str
-                )
+                logger.info("Running command '%s' in venv '%s'.", command, venv_path)
+                logger.debug("Environment variables:\n%s", env_str)
                 with nspkgs(inst):
                     try:
                         output = self.run_cmd_venv(


### PR DESCRIPTION
Logging environment variables risks leaking secrets, and likely isn't necessary in non-debugging scenarios.

Another, more complicated option, would be to have an allowlist (or blocklist) of environment variables to suppress from logging.