### PR TITLE
fix error out if list or run find no matching environments to run

### DIFF
--- a/releasenotes/notes/fix-no-matches-error-code-3cb0f6e47a4c6ae3.yaml
+++ b/releasenotes/notes/fix-no-matches-error-code-3cb0f6e47a4c6ae3.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Return a non-zero exit code when no matches to run are found.

--- a/releasenotes/notes/fix-no-matches-error-code-3cb0f6e47a4c6ae3.yaml
+++ b/releasenotes/notes/fix-no-matches-error-code-3cb0f6e47a4c6ae3.yaml
@@ -1,4 +1,4 @@
 ---
 fixes:
   - |
-    Return a non-zero exit code when no matches to run are found.
+    Return a non-zero exit code when no matches to list or run are found.

--- a/riot/riot.py
+++ b/riot/riot.py
@@ -859,7 +859,6 @@ class Session:
             finally:
                 results.append(result)
 
-
         if instances_ran_count == 0:
             logger.info("No instances were run.")
             sys.exit(1)

--- a/riot/riot.py
+++ b/riot/riot.py
@@ -906,6 +906,7 @@ class Session:
         interpreters=False,
         hash_only=False,
     ):
+        instances_found_count = 0
         python_interpreters = set()
         venv_hashes = set()
         table = None
@@ -929,6 +930,7 @@ class Session:
 
             if not inst.match_venv_pattern(venv_pattern):
                 continue
+            instances_found_count += 1
             pkgs_str = inst.full_pkg_str
             env_str = env_to_str(inst.env)
             if interpreters or hash_only:
@@ -950,6 +952,10 @@ class Session:
                     f"[italic]{pkgs_str}[/italic]",
                 )
 
+        if instances_found_count == 0:
+            logger.info("No matches found.")
+            sys.exit(1)
+
         if table:
             rich_print(table)
 
@@ -958,10 +964,6 @@ class Session:
 
         elif interpreters and python_interpreters:
             print("\n".join(sorted(python_interpreters, key=Version)))
-
-        else:
-            logger.verbose("No matches found.")
-            sys.exit(1)
 
     def generate_base_venvs(
         self,

--- a/riot/riot.py
+++ b/riot/riot.py
@@ -886,7 +886,7 @@ class Session:
         s_num = f"{num_passed} passed with {num_warnings} warnings, {num_failed} failed"
         click.echo(click.style(s_num, fg="blue", bold=True))
 
-        if any(True for r in results if r.code != 0):
+        if not results or any(r.code for r in results):
             sys.exit(1)
 
     def list_venvs(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -81,7 +81,10 @@ def test_list_with_venv_pattern(cli: click.testing.CliRunner) -> None:
 
 def test_list_with_python(cli: click.testing.CliRunner) -> None:
     """Running list with a python passes through the python."""
-    with mock.patch("riot.cli.Session.list_venvs") as list_venvs:
+    def exit1():
+        import sys
+        sys.exit(1)
+    with mock.patch("riot.cli.Session.list_venvs", side_effect=exit1) as list_venvs:
         with with_riotfile(cli, "empty_riotfile.py"):
             result = cli.invoke(riot.cli.main, ["list", "--python", "3.6"])
             # Success, but no output because we don't have a matching pattern
@@ -92,7 +95,7 @@ def test_list_with_python(cli: click.testing.CliRunner) -> None:
             assert list_venvs.call_args.kwargs["pythons"] == (Interpreter("3.6"),)
 
     # multiple pythons
-    with mock.patch("riot.cli.Session.list_venvs") as list_venvs:
+    with mock.patch("riot.cli.Session.list_venvs", side_effect=exit1) as list_venvs:
         with with_riotfile(cli, "empty_riotfile.py"):
             result = cli.invoke(
                 riot.cli.main,
@@ -114,7 +117,7 @@ def test_list_with_interpreters_only(cli: click.testing.CliRunner) -> None:
     with with_riotfile(cli, "empty_riotfile.py"):
         result = cli.invoke(riot.cli.main, ["list", "--interpreters"])
         # Success, but no output because no venvs to list
-        assert result.exit_code == 0
+        assert result.exit_code == 1
         assert result.stdout == ""
 
     with with_riotfile(cli, "simple_riotfile.py"):
@@ -133,7 +136,7 @@ def test_list_with_hash_only(cli: click.testing.CliRunner) -> None:
     with with_riotfile(cli, "empty_riotfile.py"):
         result = cli.invoke(riot.cli.main, ["list", "--hash-only"])
         # Success, but no output because no venvs to list
-        assert result.exit_code == 0
+        assert result.exit_code == 1
         assert result.stdout == ""
 
     with with_riotfile(cli, "simple_riotfile.py"):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -85,7 +85,7 @@ def test_list_with_python(cli: click.testing.CliRunner) -> None:
         with with_riotfile(cli, "empty_riotfile.py"):
             result = cli.invoke(riot.cli.main, ["list", "--python", "3.6"])
             # Success, but no output because we don't have a matching pattern
-            assert result.exit_code == 0
+            assert result.exit_code == 1
             assert result.stdout == ""
 
             list_venvs.assert_called_once()
@@ -99,7 +99,7 @@ def test_list_with_python(cli: click.testing.CliRunner) -> None:
                 ["list", "--python", "3.6", "-p", "3.8"],
             )
             # Success, but no output because we don't have a matching pattern
-            assert result.exit_code == 0
+            assert result.exit_code == 1
             assert result.stdout == ""
 
             list_venvs.assert_called_once()

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -508,7 +508,7 @@ venv = Venv(
     )
     # DEV: The hash is consistent as long as no settings change
     result = tmp_run("riot run -s 163716e")
-    assert result.returncode == 0, result.stderr
+    assert result.returncode == 1, result.stderr
 
 
 def test_run_cmdargs(tmp_path: pathlib.Path, tmp_run: _T_TmpRun) -> None:

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -208,7 +208,7 @@ from riot import Venv
     result = tmp_run("riot -P list")
     assert result.stderr == ""
     assert result.stdout == ""
-    assert result.returncode == 0
+    assert result.returncode == 1
 
 
 def test_list_configurations(tmp_path: pathlib.Path, tmp_run: _T_TmpRun) -> None:


### PR DESCRIPTION
This updates the CLI to exit with error code 1 for the `list` and `run` commands if there ends up being no matches.

The intention here is to prevent scenarios where `list` or `run` end up matching nothing, giving the caller (or in the case motivating this PR: CI runs) the false impression that tests succeeded when, in fact, it is more likely that the pattern passed to `riot` wasn't properly formed and no tests were run at all.