### PR TITLE
fix: avoid using pip caching

### DIFF
--- a/riot/riot.py
+++ b/riot/riot.py
@@ -616,7 +616,8 @@ class VenvInstance:
             if recompile_reqs or not os.path.exists(compiled_requirements_file):
                 _ = self.requirements
             cmd = (
-                f"pip --disable-pip-version-check install --prefix '{self.prefix}' --no-warn-script-location "
+                f"pip --disable-pip-version-check install --prefix '{self.prefix}' "
+                "--no-warn-script-location "
                 f"-r {compiled_requirements_file}"
             )
             logger.info(


### PR DESCRIPTION
This change attempts to fix a rare error from dd-trace-py's main-branch CI ([example](https://app.circleci.com/pipelines/github/DataDog/dd-trace-py/63709/workflows/e2369e01-0509-41a5-9edf-2eb307d48136/jobs/3952971)) in which the following is output from riot:
```
Running riot hash: 55a0f54
WARNING: Running pip as the 'root' user can result in broken permissions and conflicting behaviour with the system package manager. It is recommended to use a virtual environment instead: https://pip.pypa.io/warnings/venv
INFO:riot.riot:Generating virtual environments for interpreters Interpreter(_hint='3.7')
INFO:riot.riot:Skipping creation of virtualenv '/root/project/.riot/venv_py3716' as it already exists.
INFO:riot.riot:Skipping global deps install.
INFO:riot.riot:Running with Interpreter(_hint='3.7')
INFO:riot.riot:Installing venv dependencies .riot/requirements/55a0f54.txt at /root/project/.riot/venv_py3716_mock_pytest_pytest-mock_coverage_pytest-cov_opentracing_hypothesis6451_responses~0160_cryptography39_pytest-randomly_snowflake-connector-python~230.
ERROR: THESE PACKAGES DO NOT MATCH THE HASHES FROM THE REQUIREMENTS FILE. If you have updated the package versions, please update the hashes. Otherwise, examine the package contents carefully; someone may have tampered with them.
    unknown package:
        Expected sha256 11f7ff1c01b2aaa52c0030300b89e446a3eac2168642331c73557946e8498963
             Got        69e2889d822b7820d193d394d584a59fc86773dce09de752429b0bc5164d9ff9
```
The fix is based on the accepted answer to this StackOverflow question: https://stackoverflow.com/questions/40183108/python-packages-hash-not-matching-whilst-installing-using-pip