### PR TITLE
fix: ensure setuptools is present in riot lock files

### DIFF
--- a/releasenotes/notes/allow-unsafe-dff39e7251807993.yaml
+++ b/releasenotes/notes/allow-unsafe-dff39e7251807993.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    Ensure ``setuptools`` is included in riot generated lock files. This ensures consistent behavior
+    for packages and ``riot.Venv``s which depend on ``setuptools``.

--- a/riot/riot.py
+++ b/riot/riot.py
@@ -486,6 +486,7 @@ class VenvInstance:
             "compile",
             "-q",
             "--no-annotate",
+            "--allow-unsafe",
             in_path,
         ]
         if tuple([int(v) for v in self.py.version().strip("()").split(".")]) >= (3, 7):


### PR DESCRIPTION
By default `setuptools` is not included by `pip-compile` generated lock files.

This can cause issues for Venvs which rely on `setuptools` since it won't be included in the lock file.