### PR TITLE
fix(ci): use macos-13 instead of macos-latest

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -54,7 +54,8 @@ jobs:
   test:
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        # macos-14/latest uses arm64
+        os: [ubuntu-latest, macos-13]
         python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12", pypy-3.7]
     runs-on: ${{ matrix.os }}
     steps:


### PR DESCRIPTION
macos-14 (latest) uses arm64. there aren't python 3.7 builds for that architecture for `actions/setup-python@v4`.