### PR TITLE
ci: pin virtualenv to 20.26.6

### DIFF
--- a/releasenotes/notes/fix-python-37-virtualenv-e15bd328ac61108d.yaml
+++ b/releasenotes/notes/fix-python-37-virtualenv-e15bd328ac61108d.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    Pin ``virtualenv`` to the version that has support for Python 3.7
+

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ setup(
     install_requires=[
         "dataclasses; python_version<'3.7'",
         "click>=7",
-        "virtualenv",
+        "virtualenv<=20.26.6",
         "rich",
         "pexpect",
         "packaging",


### PR DESCRIPTION
With the new release of `virtualenv==20.27.0`, we were seeing new failures with `build_base_venv[3.7]` jobs when running:
```
riot -P -v generate --python=$PYTHON_VERSION
...
  File "/go/src/github.com/DataDog/apm-reliability/dd-trace-py/.riot/venv_py3717/lib/python3.7/site-packages/pip/_vendor/typing_extensions.py", line 1039
    def TypedDict(typename, fields=_marker, /, *, total=True, closed=False, **kwargs):
                                            ^
SyntaxError: invalid syntax
ERROR:riot.riot:Dev install failed, aborting!
```
We need to pin to `virtualenv==20.26.6` to continue supporting python3.7