### PR TITLE
ci: upload,download-artifact v2->v4

### DIFF
--- a/.github/workflows/build_deploy.yml
+++ b/.github/workflows/build_deploy.yml
@@ -27,7 +27,7 @@ jobs:
           pip install wheel
           pip wheel --no-deps -w dist .
 
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v4
         with:
           path: dist/*.whl
 
@@ -49,7 +49,7 @@ jobs:
         run: |
           python setup.py sdist
 
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v4
         with:
           path: dist/*.tar.gz
 

--- a/.github/workflows/build_deploy.yml
+++ b/.github/workflows/build_deploy.yml
@@ -29,7 +29,7 @@ jobs:
 
       - uses: actions/upload-artifact@v4
         with:
-          overwrite: true
+          name: artifact-wheel
           path: dist/*.whl
 
   build_sdist:
@@ -52,7 +52,7 @@ jobs:
 
       - uses: actions/upload-artifact@v4
         with:
-          overwrite: true
+          name: artifact-sdist
           path: dist/*.tar.gz
 
   upload_pypi:
@@ -60,9 +60,9 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event_name == 'release' && github.event.action == 'published'
     steps:
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v4
         with:
-          name: artifact
+          name: artifact-*
           path: dist
 
       - uses: pypa/gh-action-pypi-publish@master

--- a/.github/workflows/build_deploy.yml
+++ b/.github/workflows/build_deploy.yml
@@ -29,6 +29,7 @@ jobs:
 
       - uses: actions/upload-artifact@v4
         with:
+          overwrite: true
           path: dist/*.whl
 
   build_sdist:

--- a/.github/workflows/build_deploy.yml
+++ b/.github/workflows/build_deploy.yml
@@ -52,6 +52,7 @@ jobs:
 
       - uses: actions/upload-artifact@v4
         with:
+          overwrite: true
           path: dist/*.tar.gz
 
   upload_pypi:

--- a/.github/workflows/build_deploy.yml
+++ b/.github/workflows/build_deploy.yml
@@ -27,7 +27,7 @@ jobs:
           pip install wheel
           pip wheel --no-deps -w dist .
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@834a144ee995460fba8ed112a2fc961b36a5ec5a # v4.3.6
         with:
           name: artifact-wheel
           path: dist/*.whl
@@ -50,7 +50,7 @@ jobs:
         run: |
           python setup.py sdist
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@834a144ee995460fba8ed112a2fc961b36a5ec5a # v4.3.6
         with:
           name: artifact-sdist
           path: dist/*.tar.gz
@@ -60,7 +60,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event_name == 'release' && github.event.action == 'published'
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@65a9edc5881444af0b9093a5e628f2fe47ea3b2e # v4.1.7
         with:
           name: artifact-*
           path: dist

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -42,7 +42,7 @@ jobs:
           rst2html.py CHANGELOG.rst CHANGELOG.html
 
       - name: Upload CHANGELOG.rst
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: changelog
           path: |

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -42,7 +42,7 @@ jobs:
           rst2html.py CHANGELOG.rst CHANGELOG.html
 
       - name: Upload CHANGELOG.rst
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@834a144ee995460fba8ed112a2fc961b36a5ec5a # v4.3.6
         with:
           name: changelog
           path: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Install Riot
         run: pip install .
       - run: riot -v run docs
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@834a144ee995460fba8ed112a2fc961b36a5ec5a # v4.3.6
         with:
           name: docs
           path: docs/_build

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Install Riot
         run: pip install .
       - run: riot -v run docs
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v4
         with:
           name: docs
           path: docs/_build

--- a/releasenotes/notes/fix-python-37-virtualenv-e15bd328ac61108d.yaml
+++ b/releasenotes/notes/fix-python-37-virtualenv-e15bd328ac61108d.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    Pin ``virtualenv`` to the version that has support for Python 3.7
+

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ setup(
     install_requires=[
         "dataclasses; python_version<'3.7'",
         "click>=7",
-        "virtualenv",
+        "virtualenv<=20.26.6",
         "rich",
         "pexpect",
         "packaging",


### PR DESCRIPTION
With the new release of `virtualenv==20.27.0`, we were seeing new failures with `build_base_venv[3.7]` jobs when running:
```
riot -P -v generate --python=$PYTHON_VERSION
...
  File "/go/src/github.com/DataDog/apm-reliability/dd-trace-py/.riot/venv_py3717/lib/python3.7/site-packages/pip/_vendor/typing_extensions.py", line 1039
    def TypedDict(typename, fields=_marker, /, *, total=True, closed=False, **kwargs):
                                            ^
SyntaxError: invalid syntax
ERROR:riot.riot:Dev install failed, aborting!
```
We need to pin to `virtualenv==20.26.6` to continue supporting python3.7

The `upload-artifact` and `download-artifact` bumps were required to unblock the riot CI. It had been a while since the last update to riot, and since then, v2 has been deprecated and v3 will be deprecated next month (Nov 2024), so we are bumping to v4 via tag.