### PR TITLE
fix(ci): wheel and sdist artifacts should get uploaded to shared `artifact` dir

### DIFF
--- a/.github/workflows/build_deploy.yml
+++ b/.github/workflows/build_deploy.yml
@@ -1,6 +1,9 @@
 name: Build
 
 on:
+  push:
+    branches:
+      - erikayasuda/fix-upload-pypi
   pull_request:
   release:
     types:
@@ -29,6 +32,7 @@ jobs:
 
       - uses: actions/upload-artifact@834a144ee995460fba8ed112a2fc961b36a5ec5a # v4.3.6
         with:
+          name: artifact-wheel
           path: dist/*.whl
 
   build_sdist:
@@ -51,6 +55,7 @@ jobs:
 
       - uses: actions/upload-artifact@834a144ee995460fba8ed112a2fc961b36a5ec5a # v4.3.6
         with:
+          name: artifact-sdist
           path: dist/*.tar.gz
 
   upload_pypi:
@@ -60,11 +65,14 @@ jobs:
     steps:
       - uses: actions/download-artifact@65a9edc5881444af0b9093a5e628f2fe47ea3b2e # v4.1.7
         with:
-          name: artifact
+          name: artifact-sdist
           path: dist
-
+      - uses: actions/download-artifact@65a9edc5881444af0b9093a5e628f2fe47ea3b2e # v4.1.7
+        with:
+          name: artifact-wheel
+          path: dist
       - uses: pypa/gh-action-pypi-publish@master
         with:
           user: __token__
           password: ${{ secrets.PYPI_TOKEN }}
-          # To test: repository_url: https://test.pypi.org/legacy/
+          repository_url: https://test.pypi.org/legacy/

--- a/.github/workflows/build_deploy.yml
+++ b/.github/workflows/build_deploy.yml
@@ -58,7 +58,7 @@ jobs:
   upload_pypi:
     needs: [build_wheel, build_sdist]
     runs-on: ubuntu-latest
-    if: github.event_name == 'release' && github.event.action == 'published' || github.ref == 'refs/heads/test'
+    if: github.event_name == 'release' && github.event.action == 'published' || github.ref == 'refs/heads/erikayasuda/fix-upload-pypi'
     steps:
       - uses: actions/download-artifact@65a9edc5881444af0b9093a5e628f2fe47ea3b2e # v4.1.7
         with:

--- a/.github/workflows/build_deploy.yml
+++ b/.github/workflows/build_deploy.yml
@@ -67,8 +67,8 @@ jobs:
         with:
           name: artifact-wheel
           path: dist
-      - uses: pypa/gh-action-pypi-publish@master
+      - uses: pypa/gh-action-pypi-publish@release/v1
         with:
           user: __token__
           password: ${{ secrets.PYPI_TOKEN }}
-          repository_url: https://test.pypi.org/legacy/
+          repository-url: https://test.pypi.org/legacy/

--- a/.github/workflows/build_deploy.yml
+++ b/.github/workflows/build_deploy.yml
@@ -63,6 +63,7 @@ jobs:
   upload_pypi:
     needs: [build_wheel, build_sdist]
     runs-on: ubuntu-latest
+    if: github.event_name == 'release' && github.event.action == 'published'
     steps:
       - uses: actions/download-artifact@65a9edc5881444af0b9093a5e628f2fe47ea3b2e # v4.1.7
         with:
@@ -72,15 +73,8 @@ jobs:
         with:
           name: artifact-wheel
           path: dist
-      - name: Check for Secret
-        run: |
-          if [ -z "${{ secrets.PYPI_TOKEN }}" ]; then
-            echo "PYPI_TOKEN is not set"
-          else
-            echo "PYPI_TOKEN exists"
-          fi
       - uses: pypa/gh-action-pypi-publish@release/v1
         with:
           user: __token__
           password: ${{ secrets.PYPI_TOKEN }}
-          repository-url: https://test.pypi.org/legacy/
+          # To test: repository-url: https://test.pypi.org/legacy/

--- a/.github/workflows/build_deploy.yml
+++ b/.github/workflows/build_deploy.yml
@@ -29,7 +29,6 @@ jobs:
 
       - uses: actions/upload-artifact@834a144ee995460fba8ed112a2fc961b36a5ec5a # v4.3.6
         with:
-          name: artifact-wheel
           path: dist/*.whl
 
   build_sdist:
@@ -52,7 +51,6 @@ jobs:
 
       - uses: actions/upload-artifact@834a144ee995460fba8ed112a2fc961b36a5ec5a # v4.3.6
         with:
-          name: artifact-sdist
           path: dist/*.tar.gz
 
   upload_pypi:
@@ -62,7 +60,7 @@ jobs:
     steps:
       - uses: actions/download-artifact@65a9edc5881444af0b9093a5e628f2fe47ea3b2e # v4.1.7
         with:
-          name: artifact-*
+          name: artifact
           path: dist
 
       - uses: pypa/gh-action-pypi-publish@master

--- a/.github/workflows/build_deploy.yml
+++ b/.github/workflows/build_deploy.yml
@@ -58,7 +58,6 @@ jobs:
   upload_pypi:
     needs: [build_wheel, build_sdist]
     runs-on: ubuntu-latest
-    if: github.event_name == 'release' && github.event.action == 'published' || github.ref == 'refs/heads/erikayasuda/fix-upload-pypi'
     steps:
       - uses: actions/download-artifact@65a9edc5881444af0b9093a5e628f2fe47ea3b2e # v4.1.7
         with:

--- a/.github/workflows/build_deploy.yml
+++ b/.github/workflows/build_deploy.yml
@@ -1,9 +1,6 @@
 name: Build
 
 on:
-  push:
-    branches:
-      - erikayasuda/fix-upload-pypi
   pull_request:
   release:
     types:
@@ -61,7 +58,7 @@ jobs:
   upload_pypi:
     needs: [build_wheel, build_sdist]
     runs-on: ubuntu-latest
-    if: github.event_name == 'release' && github.event.action == 'published'
+    if: github.event_name == 'release' && github.event.action == 'published' || github.ref == 'refs/heads/test'
     steps:
       - uses: actions/download-artifact@65a9edc5881444af0b9093a5e628f2fe47ea3b2e # v4.1.7
         with:

--- a/.github/workflows/build_deploy.yml
+++ b/.github/workflows/build_deploy.yml
@@ -63,7 +63,6 @@ jobs:
   upload_pypi:
     needs: [build_wheel, build_sdist]
     runs-on: ubuntu-latest
-    # if: github.event_name == 'release' && github.event.action == 'published'
     steps:
       - uses: actions/download-artifact@65a9edc5881444af0b9093a5e628f2fe47ea3b2e # v4.1.7
         with:

--- a/.github/workflows/build_deploy.yml
+++ b/.github/workflows/build_deploy.yml
@@ -1,6 +1,11 @@
 name: Build
 
 on:
+  workflow_call:
+    secrets:
+      PYPI_TOKEN:
+        description: 'A token for accessing PyPI'
+        required: true
   pull_request:
   release:
     types:
@@ -58,6 +63,7 @@ jobs:
   upload_pypi:
     needs: [build_wheel, build_sdist]
     runs-on: ubuntu-latest
+    # if: github.event_name == 'release' && github.event.action == 'published'
     steps:
       - uses: actions/download-artifact@65a9edc5881444af0b9093a5e628f2fe47ea3b2e # v4.1.7
         with:

--- a/.github/workflows/build_deploy.yml
+++ b/.github/workflows/build_deploy.yml
@@ -72,6 +72,13 @@ jobs:
         with:
           name: artifact-wheel
           path: dist
+      - name: Check for Secret
+        run: |
+          if [ -z "${{ secrets.PYPI_TOKEN }}" ]; then
+            echo "PYPI_TOKEN is not set"
+          else
+            echo "PYPI_TOKEN exists"
+          fi
       - uses: pypa/gh-action-pypi-publish@release/v1
         with:
           user: __token__


### PR DESCRIPTION
We added unique names to the wheel and sdist artifacts in the last change, but that makes the download process fail because it's looking for a single directory with both of these artifacts included, not two individual artifacts.

This change continues to upload the two artifacts with unique names, but we add separate download steps for each artifact since wildcards like `artifact-*` are not supported.

We also needed to give permissions to the job to access secrets.