### PR TITLE
fix: only log env variables when debugging logging (backport #234)

### DIFF
--- a/releasenotes/notes/fix-env-debug-logging-5bf9ff1d5025dcac.yaml
+++ b/releasenotes/notes/fix-env-debug-logging-5bf9ff1d5025dcac.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Only log environment variables in debug logging.

--- a/riot/riot.py
+++ b/riot/riot.py
@@ -825,12 +825,19 @@ class Session:
                         cmdargs=(" ".join(f"'{arg}'" for arg in cmdargs))
                     ).strip()
                 env_str = "\n".join(f"{k}={v}" for k, v in env.items())
-                logger.info(
-                    "Running command '%s' in venv '%s' with environment:\n%s.",
-                    command,
-                    venv_path,
-                    env_str,
-                )
+                if logger.isEnabledFor(logging.DEBUG):
+                    logger.debug(
+                        "Running command '%s' in venv '%s' with environment:\n%s.",
+                        command,
+                        venv_path,
+                        env_str,
+                    )
+                else:
+                    logger.info(
+                        "Running command '%s' in venv '%s'.",
+                        command,
+                        venv_path,
+                    )
                 with nspkgs(inst):
                     try:
                         output = self.run_cmd_venv(


### PR DESCRIPTION
Backport of #234 