### PR TITLE
perf: cache full_pkg_str/long_hash and skip pip-tools reinstall

### DIFF
--- a/riot/venv.py
+++ b/riot/venv.py
@@ -1,5 +1,6 @@
 from contextlib import contextmanager
 import dataclasses
+import functools
 from hashlib import sha256
 import logging
 import os
@@ -244,22 +245,24 @@ class VenvInstance:
         """Return pip friendly install string from defined packages."""
         return pip_deps(self.pkgs)
 
-    @property
+    @functools.cached_property
     def full_pkg_str(self) -> str:
         """Return pip friendly install string from defined packages."""
-        chain: t.List[VenvInstance] = [self]
+        # Build chain from self up to the root (child-first order)
+        chain: t.List[VenvInstance] = []
         current: t.Optional[VenvInstance] = self
         while current is not None:
-            chain.insert(0, current)
+            chain.append(current)
             current = current.parent
 
         pkgs: t.Dict[str, str] = {}
-        for inst in chain:
+        # Iterate root-first so that child packages override parent packages
+        for inst in reversed(chain):
             pkgs.update(dict(inst.pkgs))
 
         return pip_deps(pkgs)
 
-    @property
+    @functools.cached_property
     def long_hash(self) -> str:
         return hex(hash(self))[2:]
 
@@ -283,17 +286,26 @@ class VenvInstance:
         _dir = os.path.join(DEFAULT_RIOT_PATH, "requirements")
         os.makedirs(_dir, exist_ok=True)
         in_path = os.path.join(_dir, "{}.in".format(self.short_hash))
-        subprocess.check_output(
-            [
-                self.py.path(),
-                "-m",
-                "pip",
-                "install",
-                "--upgrade",
-                "pip<26",
-                "pip-tools>=7.5.0,<8",
-            ],
+        # Only install pip-tools once per interpreter. A sentinel file keyed on
+        # the interpreter's venv path records that pip-tools is already present,
+        # avoiding a subprocess call on every requirements compilation.
+        sentinel = (
+            Path(DEFAULT_RIOT_PATH)
+            / f"pip-tools-{Path(self.py.venv_path).name}.installed"
         )
+        if not sentinel.exists():
+            subprocess.check_output(
+                [
+                    self.py.path(),
+                    "-m",
+                    "pip",
+                    "install",
+                    "--upgrade",
+                    "pip<26",
+                    "pip-tools>=7.5.0,<8",
+                ],
+            )
+            sentinel.touch()
         cmd = [
             self.py.path(),
             "-m",

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -354,6 +354,7 @@ def test_session_run_check_environment_modifications_and_recreate_true(
 def test_requirements_upgrades_compatible_pip_tools(
     monkeypatch: pytest.MonkeyPatch, tmp_path: pathlib.Path
 ) -> None:
+    """When no sentinel exists, pip-tools should be installed and the sentinel created."""
     monkeypatch.chdir(tmp_path)
     calls: List[List[str]] = []
 
@@ -387,3 +388,41 @@ def test_requirements_upgrades_compatible_pip_tools(
         "pip<26",
         "pip-tools>=7.5.0,<8",
     ]
+
+
+def test_requirements_skips_pip_tools_install_when_sentinel_exists(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: pathlib.Path
+) -> None:
+    """When the sentinel file exists, the pip install should be skipped."""
+    monkeypatch.chdir(tmp_path)
+    calls: List[List[str]] = []
+
+    interpreter = Interpreter("3")
+    monkeypatch.setattr(interpreter, "path", lambda: "/fake/python")
+    monkeypatch.setattr(interpreter, "version", lambda: "3.14.2")
+
+    # Pre-create the sentinel to simulate pip-tools already being installed
+    sentinel_dir = tmp_path / ".riot"
+    sentinel_dir.mkdir()
+    venv_basename = os.path.basename(interpreter.venv_path)
+    (sentinel_dir / f"pip-tools-{venv_basename}.installed").touch()
+
+    def _fake_check_output(cmd: List[str], *args: Any, **kwargs: Any) -> bytes:
+        calls.append(cmd)
+        if cmd[:4] == ["/fake/python", "-m", "piptools", "compile"]:
+            return b"# compiled output\nrequests==2.31.0\n"
+        return b""
+
+    monkeypatch.setattr("riot.venv.subprocess.check_output", _fake_check_output)
+
+    venv = VenvInstance(
+        venv=Venv(name="test", command="echo test"),
+        env={},
+        pkgs={"requests": ""},
+        py=interpreter,
+    )
+
+    _ = venv.requirements
+
+    # pip install should not appear in calls
+    assert not any(c[2:4] == ["-m", "pip"] for c in calls)


### PR DESCRIPTION
- Cache full_pkg_str and long_hash with cached_property so the parent chain traversal and SHA256 computation happen at most once per VenvInstance, regardless of how many times they are accessed.
- Fix the double-insert bug in full_pkg_str (self was added to the chain twice), using append + reversed for O(n) traversal.
- Skip pip-tools reinstall on every requirements compilation by writing a sentinel file (.riot/pip-tools-<venv>.installed) on first install. Subsequent compilations check for the file instead of spawning a subprocess.