### PR TITLE
feat(requirements): add uv pip compile backend with --exclude-newer support

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -28,3 +28,35 @@ Venv
 
 .. autoclass:: riot.venv.Venv
    :members:
+
+
+Environment variables
+---------------------
+
+The following environment variables influence riot's behaviour:
+
+``RIOT_PATTERN``
+    Default value for the ``pattern`` argument of ``list``, ``run`` and
+    ``generate``.
+
+``RIOT_ENV_BASE_PATH``
+    Base directory under which virtual environments are created.
+    Defaults to ``.riot`` (relative to the current working directory).
+
+``RIOT_PIP_COMPILE_BACKEND``
+    Selects the compiler used when generating lockfiles via the
+    ``requirements`` command. Supported values:
+
+    - ``piptools`` (default) — invoke ``python -m piptools compile``;
+      ``pip-tools`` is auto-installed on demand.
+    - ``uv`` — invoke ``uv pip compile``. The ``uv`` executable must
+      already be available on ``PATH``; a clear error is raised
+      otherwise.
+
+``RIOT_PIP_COMPILE_EXCLUDE_NEWER``
+    When set together with ``RIOT_PIP_COMPILE_BACKEND=uv``, the value is
+    forwarded to ``uv pip compile`` as ``--exclude-newer=<value>`` so
+    that releases published after the given timestamp are not picked up
+    during lockfile resolution. Useful for enforcing a supply-chain
+    "cooldown" on freshly published transitive dependencies. Ignored
+    with a warning when the backend is ``piptools``.

--- a/releasenotes/notes/uv-pip-compile-backend-71f6f1bdc62c9c10.yaml
+++ b/releasenotes/notes/uv-pip-compile-backend-71f6f1bdc62c9c10.yaml
@@ -1,0 +1,4 @@
+---
+features:
+  - |
+    Add an opt-in ``uv pip compile`` backend (``RIOT_PIP_COMPILE_BACKEND=uv``) that forwards ``RIOT_PIP_COMPILE_EXCLUDE_NEWER`` as ``--exclude-newer``.

--- a/riot/cli.py
+++ b/riot/cli.py
@@ -226,7 +226,18 @@ def shell(ctx, ident, pass_env):
     )
 
 
-@main.command("requirements", help="""Cache requirements for a venv.""")
+@main.command(
+    "requirements",
+    help=(
+        "Cache requirements for a venv.\n\n"
+        "The compiler is selectable via the RIOT_PIP_COMPILE_BACKEND env var: "
+        "'piptools' (default) or 'uv' (requires the uv executable on PATH).\n\n"
+        "When RIOT_PIP_COMPILE_BACKEND=uv, the RIOT_PIP_COMPILE_EXCLUDE_NEWER "
+        "env var is forwarded as --exclude-newer=<value> to 'uv pip compile' "
+        "(useful for supply-chain cooldown). Ignored with a warning when the "
+        "backend is pip-tools."
+    ),
+)
 @click.argument("ident", type=str)
 @click.pass_context
 def requirements(ctx, ident):

--- a/riot/venv.py
+++ b/riot/venv.py
@@ -280,47 +280,112 @@ class VenvInstance:
 
     @property
     def requirements(self) -> str:
-        """Requirements for dependencies with pinned versions."""
+        """Requirements for dependencies with pinned versions.
+
+        The compiler used to lock the requirements is selectable via the
+        ``RIOT_PIP_COMPILE_BACKEND`` environment variable. Supported values:
+
+        - ``piptools`` (default): use ``python -m piptools compile``, the
+          historical behaviour. ``pip-tools`` is auto-installed on demand.
+        - ``uv``: use ``uv pip compile``. The ``uv`` executable must already
+          be available on ``PATH``. This backend supports the additional
+          ``RIOT_PIP_COMPILE_EXCLUDE_NEWER`` environment variable, which is
+          forwarded as ``--exclude-newer=<value>`` to ``uv pip compile`` and
+          lets callers enforce a supply-chain "cooldown" on freshly
+          published transitive releases.
+
+        ``RIOT_PIP_COMPILE_EXCLUDE_NEWER`` is silently ignored when the
+        backend is ``piptools`` because ``pip-tools`` has no equivalent
+        option; callers that need the cooldown must opt in to the ``uv``
+        backend.
+        """
         # Transform full_pkg_str into requirements.in format
         pkgs = "\n".join(self.full_pkg_str.replace("'", "").split(" "))
         _dir = os.path.join(DEFAULT_RIOT_PATH, "requirements")
         os.makedirs(_dir, exist_ok=True)
         in_path = os.path.join(_dir, "{}.in".format(self.short_hash))
-        # Only install pip-tools once per interpreter. A sentinel file keyed on
-        # the interpreter's venv path records that pip-tools is already present,
-        # avoiding a subprocess call on every requirements compilation.
-        sentinel = (
-            Path(DEFAULT_RIOT_PATH)
-            / f"pip-tools-{Path(self.py.venv_path).name}.installed"
-        )
-        if not sentinel.exists():
-            subprocess.check_output(
-                [
-                    self.py.path(),
-                    "-m",
-                    "pip",
-                    "install",
-                    "--upgrade",
-                    "pip<26",
-                    "pip-tools>=7.5.0,<8",
-                ],
+        out_path = os.path.join(_dir, "{}.txt".format(self.short_hash))
+
+        backend = os.environ.get("RIOT_PIP_COMPILE_BACKEND", "piptools").lower()
+        exclude_newer = os.environ.get("RIOT_PIP_COMPILE_EXCLUDE_NEWER")
+
+        if backend == "uv":
+            uv_exe = shutil.which("uv")
+            if uv_exe is None:
+                raise RuntimeError(
+                    "RIOT_PIP_COMPILE_BACKEND=uv was requested but no `uv` executable "
+                    "was found on PATH. Install uv (https://docs.astral.sh/uv/) or "
+                    "unset RIOT_PIP_COMPILE_BACKEND to fall back to pip-tools."
+                )
+            cmd = [
+                uv_exe,
+                "pip",
+                "compile",
+                "--quiet",
+                "--no-annotate",
+                "--no-strip-extras",
+                "--python",
+                self.py.path(),
+                "--output-file",
+                out_path,
+            ]
+            if exclude_newer:
+                cmd.extend(["--exclude-newer", exclude_newer])
+            cmd.append(in_path)
+        elif backend in ("piptools", "pip-tools", ""):
+            if exclude_newer:
+                logger.warning(
+                    "RIOT_PIP_COMPILE_EXCLUDE_NEWER is set but has no effect with the "
+                    "pip-tools backend; set RIOT_PIP_COMPILE_BACKEND=uv to enforce it."
+                )
+            # Only install pip-tools once per interpreter. A sentinel file
+            # keyed on the interpreter's venv path records that pip-tools is
+            # already present, avoiding a subprocess call on every
+            # requirements compilation.
+            sentinel = (
+                Path(DEFAULT_RIOT_PATH)
+                / f"pip-tools-{Path(self.py.venv_path).name}.installed"
             )
-            sentinel.touch()
-        cmd = [
-            self.py.path(),
-            "-m",
-            "piptools",
-            "compile",
-            "-q",
-            "--no-annotate",
-            "--allow-unsafe",
-            "--resolver=backtracking",
-            in_path,
-        ]
+            if not sentinel.exists():
+                subprocess.check_output(
+                    [
+                        self.py.path(),
+                        "-m",
+                        "pip",
+                        "install",
+                        "--upgrade",
+                        "pip<26",
+                        "pip-tools>=7.5.0,<8",
+                    ],
+                )
+                sentinel.touch()
+            cmd = [
+                self.py.path(),
+                "-m",
+                "piptools",
+                "compile",
+                "-q",
+                "--no-annotate",
+                "--allow-unsafe",
+                "--resolver=backtracking",
+                in_path,
+            ]
+        else:
+            raise ValueError(
+                f"Unknown RIOT_PIP_COMPILE_BACKEND={backend!r}; expected "
+                "'piptools' or 'uv'."
+            )
+
         logger.info(
-            "Compiling requirements file %s at %s.",
+            "Compiling requirements file %s at %s (backend=%s%s).",
             in_path,
             self.prefix,
+            backend or "piptools",
+            (
+                f", exclude_newer={exclude_newer}"
+                if (backend == "uv" and exclude_newer)
+                else ""
+            ),
         )
         with open(in_path, "w+b") as f:
             f.write(pkgs.encode("utf-8"))
@@ -328,6 +393,12 @@ class VenvInstance:
 
             out = subprocess.check_output(cmd)
 
+            if backend == "uv":
+                # uv writes to --output-file directly and prints nothing on
+                # stdout. Read the file back so the property contract (it
+                # returns the compiled lockfile contents) is preserved.
+                with open(out_path, "r") as out_f:
+                    return out_f.read()
             return out.decode("utf-8")
 
     @property

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -449,3 +449,174 @@ def test_requirements_skips_pip_tools_install_when_sentinel_exists(
 
     # pip install should not appear in calls
     assert not any(c[2:4] == ["-m", "pip"] for c in calls)
+
+
+def test_requirements_uses_uv_backend(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: pathlib.Path
+) -> None:
+    """RIOT_PIP_COMPILE_BACKEND=uv runs ``uv pip compile`` instead of pip-tools."""
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("RIOT_PIP_COMPILE_BACKEND", "uv")
+    monkeypatch.delenv("RIOT_PIP_COMPILE_EXCLUDE_NEWER", raising=False)
+
+    calls: List[List[str]] = []
+
+    interpreter = Interpreter("3")
+    monkeypatch.setattr(interpreter, "path", lambda: "/fake/python")
+    monkeypatch.setattr(interpreter, "version", lambda: "3.14.2")
+
+    monkeypatch.setattr(
+        "riot.venv.shutil.which", lambda name: "/fake/uv" if name == "uv" else None
+    )
+
+    def _fake_check_output(cmd: List[str], *args: Any, **kwargs: Any) -> bytes:
+        calls.append(cmd)
+        # uv writes the lockfile via --output-file; mimic that side effect.
+        if cmd[0] == "/fake/uv":
+            try:
+                out_idx = cmd.index("--output-file") + 1
+            except ValueError:
+                out_idx = None
+            if out_idx is not None:
+                with open(cmd[out_idx], "w") as f:
+                    f.write("# uv compiled output\nrequests==2.31.0\n")
+        return b""
+
+    monkeypatch.setattr("riot.venv.subprocess.check_output", _fake_check_output)
+
+    venv = VenvInstance(
+        venv=Venv(name="test", command="echo test"),
+        env={},
+        pkgs={"requests": ""},
+        py=interpreter,
+    )
+
+    result = venv.requirements
+
+    assert any(
+        c[0] == "/fake/uv" and c[1:4] == ["pip", "compile", "--quiet"] for c in calls
+    ), calls
+    # No pip-tools install fallback when uv is the backend
+    assert not any(c[2:4] == ["-m", "pip"] for c in calls)
+    assert "requests==2.31.0" in result
+
+
+def test_requirements_uv_backend_forwards_exclude_newer(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: pathlib.Path
+) -> None:
+    """RIOT_PIP_COMPILE_EXCLUDE_NEWER is passed through to ``uv pip compile``."""
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("RIOT_PIP_COMPILE_BACKEND", "uv")
+    monkeypatch.setenv("RIOT_PIP_COMPILE_EXCLUDE_NEWER", "2026-05-18T00:00:00Z")
+
+    calls: List[List[str]] = []
+
+    interpreter = Interpreter("3")
+    monkeypatch.setattr(interpreter, "path", lambda: "/fake/python")
+    monkeypatch.setattr(interpreter, "version", lambda: "3.14.2")
+    monkeypatch.setattr(
+        "riot.venv.shutil.which", lambda name: "/fake/uv" if name == "uv" else None
+    )
+
+    def _fake_check_output(cmd: List[str], *args: Any, **kwargs: Any) -> bytes:
+        calls.append(cmd)
+        if cmd[0] == "/fake/uv":
+            out_idx = cmd.index("--output-file") + 1
+            with open(cmd[out_idx], "w") as f:
+                f.write("requests==2.31.0\n")
+        return b""
+
+    monkeypatch.setattr("riot.venv.subprocess.check_output", _fake_check_output)
+
+    venv = VenvInstance(
+        venv=Venv(name="test", command="echo test"),
+        env={},
+        pkgs={"requests": ""},
+        py=interpreter,
+    )
+
+    _ = venv.requirements
+
+    uv_call = next(c for c in calls if c[0] == "/fake/uv")
+    assert "--exclude-newer" in uv_call
+    assert uv_call[uv_call.index("--exclude-newer") + 1] == "2026-05-18T00:00:00Z"
+
+
+def test_requirements_uv_backend_raises_when_uv_missing(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: pathlib.Path
+) -> None:
+    """An uv backend request with no uv on PATH must fail loudly."""
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("RIOT_PIP_COMPILE_BACKEND", "uv")
+
+    interpreter = Interpreter("3")
+    monkeypatch.setattr(interpreter, "path", lambda: "/fake/python")
+    monkeypatch.setattr(interpreter, "version", lambda: "3.14.2")
+    monkeypatch.setattr("riot.venv.shutil.which", lambda name: None)
+
+    venv = VenvInstance(
+        venv=Venv(name="test", command="echo test"),
+        env={},
+        pkgs={"requests": ""},
+        py=interpreter,
+    )
+
+    with pytest.raises(RuntimeError, match="uv"):
+        _ = venv.requirements
+
+
+def test_requirements_rejects_unknown_backend(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: pathlib.Path
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("RIOT_PIP_COMPILE_BACKEND", "poetry")
+
+    interpreter = Interpreter("3")
+    monkeypatch.setattr(interpreter, "path", lambda: "/fake/python")
+    monkeypatch.setattr(interpreter, "version", lambda: "3.14.2")
+
+    venv = VenvInstance(
+        venv=Venv(name="test", command="echo test"),
+        env={},
+        pkgs={"requests": ""},
+        py=interpreter,
+    )
+
+    with pytest.raises(ValueError, match="poetry"):
+        _ = venv.requirements
+
+
+def test_requirements_piptools_warns_about_exclude_newer(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: pathlib.Path,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """RIOT_PIP_COMPILE_EXCLUDE_NEWER is ignored with a warning for the pip-tools backend."""
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.delenv("RIOT_PIP_COMPILE_BACKEND", raising=False)
+    monkeypatch.setenv("RIOT_PIP_COMPILE_EXCLUDE_NEWER", "2026-05-18T00:00:00Z")
+
+    interpreter = Interpreter("3")
+    monkeypatch.setattr(interpreter, "path", lambda: "/fake/python")
+    monkeypatch.setattr(interpreter, "version", lambda: "3.14.2")
+
+    def _fake_check_output(cmd: List[str], *args: Any, **kwargs: Any) -> bytes:
+        if cmd[:4] == ["/fake/python", "-m", "piptools", "compile"]:
+            return b"requests==2.31.0\n"
+        return b""
+
+    monkeypatch.setattr("riot.venv.subprocess.check_output", _fake_check_output)
+
+    venv = VenvInstance(
+        venv=Venv(name="test", command="echo test"),
+        env={},
+        pkgs={"requests": ""},
+        py=interpreter,
+    )
+
+    with caplog.at_level("WARNING", logger="riot.venv"):
+        _ = venv.requirements
+
+    assert any(
+        "RIOT_PIP_COMPILE_EXCLUDE_NEWER" in record.message for record in caplog.records
+    )


### PR DESCRIPTION
## Summary

Adds an opt-in `uv pip compile` backend to `VenvInstance.requirements`, selectable via two new environment variables:

- `RIOT_PIP_COMPILE_BACKEND`: `piptools` (default) or `uv`.
- `RIOT_PIP_COMPILE_EXCLUDE_NEWER`: forwarded to `uv pip compile` as `--exclude-newer=<value>`. Ignored (with a warning) when the backend is `piptools` because pip-tools has no equivalent option.

The historical behaviour is preserved exactly when neither variable is set. When the `uv` backend is selected the `uv` executable must already be on `PATH`; a clear `RuntimeError` is raised if it isn't.

## Why

Cross-language supply-chain hardening work in `dd-trace-py` (tracked in [DataDog/dd-trace-py#18182](https://github.com/DataDog/dd-trace-py/pull/18182)) needs a 48h "cooldown" on every release that ends up in a compiled lockfile, including transitive dependencies. `--exclude-newer=<date>` is the ergonomic primitive for that on `uv pip compile`; `pip-tools` has nothing equivalent. Rather than fork riot or post-process its output, projects can now flip a single env var and get the cooldown for free.


